### PR TITLE
Add Soundcloud embeds for songs and playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ https://soundcloud.com/clemenswenners/africa
   scrolling="no"
   frameborder="no"
   allow="autoplay"
-  src=https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclemenswenners%2Fafrica&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true
+  src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true
 ></iframe>
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ https://codesandbox.io/s/ynn88nx9x?view=split
 The returned HTML snippet from the Twitter transformer will only be
 automatically recognized as an [Embedded Tweet][embedded-tweet-docs] when
 [Twitter's widget JavaScript][twitter-widget-javascript-docs] is included on the
-page.
-
+page.  
 Since the Twitter transformer doesn't include this JavaScript (because we don't
 want to include it multiple times on a page when having multiple embeds), you
 have to include it yourself. The recommended way of including it is by using

--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ https://soundcloud.com/clemenswenners/africa
   height="300"
   scrolling="no"
   frameborder="no"
-  allow="autoplay"
   src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true
 ></iframe>
 ```

--- a/README.md
+++ b/README.md
@@ -97,10 +97,9 @@ https://codesandbox.io/s/ynn88nx9x?view=split
 The returned HTML snippet from the Twitter transformer will only be
 automatically recognized as an [Embedded Tweet][embedded-tweet-docs] when
 [Twitter's widget JavaScript][twitter-widget-javascript-docs] is included on the
-page.  
-Since the Twitter transformer doesn't include this JavaScript (because we don't
-want to include it multiple times on a page when having multiple embeds), you
-have to include it yourself. The recommended way of including it is by using
+page. Since the Twitter transformer doesn't include this JavaScript (because we
+don't want to include it multiple times on a page when having multiple embeds),
+you have to include it yourself. The recommended way of including it is by using
 [`gatsby-plugin-twitter`][gatsby-plugin-twitter].
 
 #### Usage
@@ -157,6 +156,27 @@ https://youtu.be/dQw4w9WgXcQ
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
+></iframe>
+```
+
+### Soundcloud
+
+#### Usage
+
+```md
+https://soundcloud.com/clemenswenners/africa
+```
+
+#### Result
+
+```md
+<iframe
+  width="100%"
+  height="300"
+  scrolling="no"
+  frameborder="no"
+  allow="autoplay"
+  src=https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclemenswenners%2Fafrica&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true
 ></iframe>
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 ## The problem
 
 Trying to embed well known services (like [CodeSandbox][codesandbox],
-[Twitter][twitter] or [YouTube][youtube]) into your [Gatsby][gatsby] website can
-be hard, since you have to know how this needs to be done for all of these
-different services.
+[SoundCloud][soundcloud], [Twitter][twitter] or [YouTube][youtube]) into your
+[Gatsby][gatsby] website can be hard, since you have to know how this needs to
+be done for all of these different services.
 
 ## This solution
 
@@ -36,6 +36,7 @@ line and replace it with the proper embed-code.
 - [Usage](#usage)
 - [Supported services](#supported-services)
   - [CodeSandbox](#codesandbox)
+  - [SoundCloud](#soundcloud)
   - [Twitter](#twitter)
   - [YouTube](#youtube)
 - [Inspiration](#inspiration)
@@ -89,6 +90,27 @@ https://codesandbox.io/s/ynn88nx9x?view=split
 <iframe
   src="https://codesandbox.io/embed/ynn88nx9x?view=split"
   style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+></iframe>
+```
+
+### SoundCloud
+
+#### Usage
+
+```md
+https://soundcloud.com/clemenswenners/africa
+```
+
+#### Result
+
+```md
+<iframe
+  width="100%"
+  height="300"
+  scrolling="no"
+  frameborder="no"
+  allow="autoplay"
+  src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true
 ></iframe>
 ```
 
@@ -157,27 +179,6 @@ https://youtu.be/dQw4w9WgXcQ
   frameborder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
-></iframe>
-```
-
-### Soundcloud
-
-#### Usage
-
-```md
-https://soundcloud.com/clemenswenners/africa
-```
-
-#### Result
-
-```md
-<iframe
-  width="100%"
-  height="300"
-  scrolling="no"
-  frameborder="no"
-  allow="autoplay"
-  src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true
 ></iframe>
 ```
 
@@ -257,6 +258,7 @@ MIT
 [gatsby]: https://github.com/gatsbyjs/gatsby
 [gatsby-plugin-twitter]: https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter
 [kentcdodds.com-repo]: https://github.com/kentcdodds/kentcdodds.com
+[soundcloud]: https://soundcloud.com
 [twitter]: https://twitter.com
 [twitter-widget-javascript-docs]: https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/overview
 [youtube]: https://youtube.com

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ https://codesandbox.io/s/ynn88nx9x?view=split
 The returned HTML snippet from the Twitter transformer will only be
 automatically recognized as an [Embedded Tweet][embedded-tweet-docs] when
 [Twitter's widget JavaScript][twitter-widget-javascript-docs] is included on the
-page. Since the Twitter transformer doesn't include this JavaScript (because we
-don't want to include it multiple times on a page when having multiple embeds),
-you have to include it yourself. The recommended way of including it is by using
+page.
+
+Since the Twitter transformer doesn't include this JavaScript (because we don't
+want to include it multiple times on a page when having multiple embeds), you
+have to include it yourself. The recommended way of including it is by using
 [`gatsby-plugin-twitter`][gatsby-plugin-twitter].
 
 #### Usage

--- a/src/__tests__/soundcloud.js
+++ b/src/__tests__/soundcloud.js
@@ -25,8 +25,12 @@ cases(
         'https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa',
       valid: false,
     },
-    'soundcloud full-name url': {
+    'valid soundcloud url with https protocol': {
       url: 'https://soundcloud.com/clemenswenners/africa',
+      valid: true,
+    },
+    'valid soundcloud url with http protocol': {
+      url: 'http://soundcloud.com/clemenswenners/africa',
       valid: true,
     },
   }

--- a/src/__tests__/soundcloud.js
+++ b/src/__tests__/soundcloud.js
@@ -36,6 +36,6 @@ test('Gets the correct Soundcloud iframe', async () => {
   const html = await getHTML('https://soundcloud.com/clemenswenners/africa');
 
   expect(html).toMatchInlineSnapshot(
-    `"<iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" allow=\\"autoplay\\" src=https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclemenswenners%2Fafrica&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true></iframe>"`
+    `"<iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" allow=\\"autoplay\\" src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe>"`
   );
 });

--- a/src/__tests__/soundcloud.js
+++ b/src/__tests__/soundcloud.js
@@ -1,0 +1,41 @@
+import cases from 'jest-in-case';
+
+import { getHTML, shouldTransform } from '../soundcloud';
+
+cases(
+  'url validation',
+  ({ url, valid }) => {
+    expect(shouldTransform(url)).toBe(valid);
+  },
+  {
+    'non-soundcloud url': {
+      url: 'https://not-a-soundcloud-url.com',
+      valid: false,
+    },
+    'url with soundcloud track id': {
+      url: 'https://api.soundcloud.com/tracks/151129490',
+      valid: false,
+    },
+    'url with soundcloud playlist id': {
+      url: 'https://api.soundcloud.com/playlists/703823211',
+      valid: false,
+    },
+    'url with widget soundcloud subdomain': {
+      url:
+        'https://w.soundcloud.com/player/?url=https://soundcloud.com/clemenswenners/africa',
+      valid: false,
+    },
+    'soundcloud full-name url': {
+      url: 'https://soundcloud.com/clemenswenners/africa',
+      valid: true,
+    },
+  }
+);
+
+test('Gets the correct Soundcloud iframe', async () => {
+  const html = await getHTML('https://soundcloud.com/clemenswenners/africa');
+
+  expect(html).toMatchInlineSnapshot(
+    `"<iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" allow=\\"autoplay\\" src=https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fclemenswenners%2Fafrica&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true></iframe>"`
+  );
+});

--- a/src/__tests__/soundcloud.js
+++ b/src/__tests__/soundcloud.js
@@ -40,6 +40,6 @@ test('Gets the correct Soundcloud iframe', async () => {
   const html = await getHTML('https://soundcloud.com/clemenswenners/africa');
 
   expect(html).toMatchInlineSnapshot(
-    `"<iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" allow=\\"autoplay\\" src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe>"`
+    `"<iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe>"`
   );
 });

--- a/src/__tests__/soundcloud.js
+++ b/src/__tests__/soundcloud.js
@@ -22,7 +22,7 @@ cases(
     },
     'url with widget soundcloud subdomain': {
       url:
-        'https://w.soundcloud.com/player/?url=https://soundcloud.com/clemenswenners/africa',
+        'https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa',
       valid: false,
     },
     'soundcloud full-name url': {

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,13 @@ import visit from 'unist-util-visit';
 import * as CodeSandboxTransformer from './codesandbox';
 import * as TwitterTransformer from './twitter';
 import * as YouTubeTransformer from './youtube';
+import * as SoundcloudTransformer from './soundcloud';
 
 const transformers = [
   YouTubeTransformer,
   TwitterTransformer,
   CodeSandboxTransformer,
+  SoundcloudTransformer,
 ];
 
 const getUrlString = string => {

--- a/src/soundcloud.js
+++ b/src/soundcloud.js
@@ -1,23 +1,19 @@
 import { URL } from 'url';
 
-export const shouldTransform = string => {
-  return new URL(string).host === 'soundcloud.com';
-};
+export const shouldTransform = string =>
+  new URL(string).host === 'soundcloud.com';
 
-const getSoundcloudIFrameSrc = string => {
-  return (
-    `https://w.soundcloud.com/player/` +
-    `?url=${encodeURIComponent(string)}` +
-    `&color=%23ff5500` +
-    `&auto_play=false` +
-    `&hide_related=false` +
-    `&show_comments=true` +
-    `&show_user=true` +
-    `&show_reposts=false` +
-    `&show_teaser=true` +
-    `&visual=true`
-  );
-};
+const getSoundcloudIFrameSrc = string =>
+  `https://w.soundcloud.com/player/` +
+  `?url=${encodeURIComponent(string)}` +
+  `&color=%23ff5500` +
+  `&auto_play=false` +
+  `&hide_related=false` +
+  `&show_comments=true` +
+  `&show_user=true` +
+  `&show_reposts=false` +
+  `&show_teaser=true` +
+  `&visual=true`;
 
 export const getHTML = string => {
   const iframeUrl = getSoundcloudIFrameSrc(string);

--- a/src/soundcloud.js
+++ b/src/soundcloud.js
@@ -1,0 +1,35 @@
+import { URL } from 'url';
+
+export const shouldTransform = string => {
+  return new URL(string).host === 'soundcloud.com';
+};
+
+const getSoundcloudIFrameSrc = string => {
+  return (
+    `https://w.soundcloud.com/player/` +
+    `?url=${encodeURIComponent(string)}` +
+    `&color=%23ff5500` +
+    `&auto_play=false` +
+    `&hide_related=false` +
+    `&show_comments=true` +
+    `&show_user=true` +
+    `&show_reposts=false` +
+    `&show_teaser=true` +
+    `&visual=true`
+  );
+};
+
+export const getHTML = string => {
+  const iframeUrl = getSoundcloudIFrameSrc(string);
+
+  return (
+    `<iframe` +
+    ` width="100%"` +
+    ` height="300"` +
+    ` scrolling="no"` +
+    ` frameborder="no"` +
+    ` allow="autoplay"` +
+    ` src=${iframeUrl}` +
+    `></iframe>`
+  );
+};

--- a/src/soundcloud.js
+++ b/src/soundcloud.js
@@ -4,15 +4,15 @@ export const shouldTransform = string =>
   new URL(string).host === 'soundcloud.com';
 
 const getSoundcloudIFrameSrc = string =>
-  `https://w.soundcloud.com/player/` +
-  `?url=${encodeURIComponent(string)}` +
-  `&color=%23ff5500` +
+  `https://w.soundcloud.com/player` +
+  `?url=${string}` +
+  `&color=ff5500` +
   `&auto_play=false` +
-  `&hide_related=false` +
+  `&hide_related=true` +
   `&show_comments=true` +
   `&show_user=true` +
   `&show_reposts=false` +
-  `&show_teaser=true` +
+  `&show_teaser=false` +
   `&visual=true`;
 
 export const getHTML = string => {

--- a/src/soundcloud.js
+++ b/src/soundcloud.js
@@ -4,28 +4,10 @@ export const shouldTransform = string =>
   new URL(string).host === 'soundcloud.com';
 
 const getSoundcloudIFrameSrc = string =>
-  `https://w.soundcloud.com/player` +
-  `?url=${string}` +
-  `&color=ff5500` +
-  `&auto_play=false` +
-  `&hide_related=true` +
-  `&show_comments=true` +
-  `&show_user=true` +
-  `&show_reposts=false` +
-  `&show_teaser=false` +
-  `&visual=true`;
+  `https://w.soundcloud.com/player?url=${string}&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true`;
 
 export const getHTML = string => {
   const iframeUrl = getSoundcloudIFrameSrc(string);
 
-  return (
-    `<iframe` +
-    ` width="100%"` +
-    ` height="300"` +
-    ` scrolling="no"` +
-    ` frameborder="no"` +
-    ` allow="autoplay"` +
-    ` src=${iframeUrl}` +
-    `></iframe>`
-  );
+  return `<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src=${iframeUrl}></iframe>`;
 };

--- a/src/soundcloud.js
+++ b/src/soundcloud.js
@@ -9,5 +9,5 @@ const getSoundcloudIFrameSrc = string =>
 export const getHTML = string => {
   const iframeUrl = getSoundcloudIFrameSrc(string);
 
-  return `<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src=${iframeUrl}></iframe>`;
+  return `<iframe width="100%" height="300" scrolling="no" frameborder="no" src=${iframeUrl}></iframe>`;
 };


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Hello! After sorting through some trouble with other gatsby embed plugins, I found this project a few days ago and I'm already excited about it. Thanks for the hard work! 

I saw that Soundcloud embeds was an issue in #3, so I went ahead and gave it a go.

Closes #3

**What**:

Add Soundcloud embeds

**Why**:

Existing issue #3 

**How**:

1. Validate the URL is a standard song or playlist URL (e.g. `https://soundcloud.com/clemenswenners/africa`)
2. Generate an iframe url that mirrors the standard Soundcloud embed generated from their website* (e.g. Go to song/playlist > Share > Embed)
3. Return the iframe HTML string

**Screenshots**:

I created a CodeSandbox example to demo the output and to compare its appearance to the typical Soundcloud embed. Check it out below

https://codesandbox.io/s/soundcloud-dynamic-embed-zkjm9

<img src="https://user-images.githubusercontent.com/5567838/64249652-0b02ec00-cec9-11e9-9dda-e4dd00af1187.png" width="300"/>

<img src="https://user-images.githubusercontent.com/5567838/64249448-857f3c00-cec8-11e9-825d-de438d981bac.png" width="300" />

***Implementation Notes**:

- By default, I've set the Soundcloud embed to NOT autoplay. Because this is a library, I thought it would be more flexible for most consumers' use cases (e.g. in case they want to embed multiple Soundcloud songs/playlists in succession)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged