### PR TITLE
fix(Slides): Fix Slides team Decks

### DIFF
--- a/src/Slides.js
+++ b/src/Slides.js
@@ -4,7 +4,7 @@ const getTrimmedPathName = pathname =>
   // Trim leading and trailing slashes
   pathname.replace(/^\/|\/+$/g, '');
 
-const isSubDomain = host => /^([a-zA-Z-]+\.)?slides\.com$/.test(host);
+const isSubDomain = host => /^([a-zA-Z-_]+\.)?slides\.com$/.test(host);
 
 export const shouldTransform = url => {
   const { host, pathname } = new URL(url);

--- a/src/Slides.js
+++ b/src/Slides.js
@@ -4,12 +4,13 @@ const getTrimmedPathName = pathname =>
   // Trim leading and trailing slashes
   pathname.replace(/^\/|\/+$/g, '');
 
+const isSubDomain = host => /^(.*\.)?slides\.com$/.test(host);
+
 export const shouldTransform = url => {
   const { host, pathname } = new URL(url);
 
   return (
-    ['slides.com', 'www.slides.com', 'team.slides.com'].includes(host) &&
-    getTrimmedPathName(pathname).split('/').length === 2
+    isSubDomain(host) && getTrimmedPathName(pathname).split('/').length === 2
   );
 };
 

--- a/src/Slides.js
+++ b/src/Slides.js
@@ -4,7 +4,7 @@ const getTrimmedPathName = pathname =>
   // Trim leading and trailing slashes
   pathname.replace(/^\/|\/+$/g, '');
 
-const isSubDomain = host => /^([a-zA-Z-_]+\.)?slides\.com$/.test(host);
+const isSubDomain = host => /^([a-zA-Z0-9-_]+\.)?slides\.com$/.test(host);
 
 export const shouldTransform = url => {
   const { host, pathname } = new URL(url);

--- a/src/Slides.js
+++ b/src/Slides.js
@@ -4,7 +4,7 @@ const getTrimmedPathName = pathname =>
   // Trim leading and trailing slashes
   pathname.replace(/^\/|\/+$/g, '');
 
-const isSubDomain = host => /^([a-zA-Z0-9-_]+\.)?slides\.com$/.test(host);
+const isSubDomain = host => /^([a-zA-Z0-9-_]{2,}\.)?slides\.com$/.test(host);
 
 export const shouldTransform = url => {
   const { host, pathname } = new URL(url);

--- a/src/Slides.js
+++ b/src/Slides.js
@@ -4,7 +4,7 @@ const getTrimmedPathName = pathname =>
   // Trim leading and trailing slashes
   pathname.replace(/^\/|\/+$/g, '');
 
-const isSubDomain = host => /^(.*\.)?slides\.com$/.test(host);
+const isSubDomain = host => /^([a-zA-Z-]+\.)?slides\.com$/.test(host);
 
 export const shouldTransform = url => {
   const { host, pathname } = new URL(url);

--- a/src/__tests__/Slides.js
+++ b/src/__tests__/Slides.js
@@ -60,6 +60,18 @@ cases(
       url: 'https://team.slides.com/hakimel/finch',
       valid: true,
     },
+    'team Deck url with custom team subdomain': {
+      url: 'https://acme.slides.com/jack-k/sales-template',
+      valid: true,
+    },
+    'team Deck url with custom hyphened team subdomain': {
+      url: 'https://team-name.slides.com/username/deck-name',
+      valid: true,
+    },
+    'team Deck url with custom dotted team subdomain': {
+      url: 'https://dotted.team.slides.com/username/deck-name',
+      valid: true,
+    },
     'team Deck url with selected page': {
       url: 'https://team.slides.com/hakimel/finch#/0',
       valid: true,
@@ -69,15 +81,15 @@ cases(
       valid: true,
     },
     "team Deck url having 'embed' as name": {
-      url: 'https://team.slides.com/teamname/embed',
+      url: 'https://team.slides.com/username/embed',
       valid: true,
     },
     "team Deck url having 'fullscreen' as name": {
-      url: 'https://team.slides.com/teamname/fullscreen',
+      url: 'https://team.slides.com/username/fullscreen',
       valid: true,
     },
     "team Deck url having 'live' as name": {
-      url: 'https://team.slides.com/teamname/live',
+      url: 'https://team.slides.com/username/live',
       valid: true,
     },
     'user Deck url': {

--- a/src/__tests__/Slides.js
+++ b/src/__tests__/Slides.js
@@ -72,6 +72,10 @@ cases(
       url: 'https://team-name.slides.com/username/deck-name',
       valid: true,
     },
+    'team Deck url with custom underscored team subdomain': {
+      url: 'https://team_name.slides.com/username/deck-name',
+      valid: true,
+    },
     'team Deck url with selected page': {
       url: 'https://team.slides.com/hakimel/finch#/0',
       valid: true,

--- a/src/__tests__/Slides.js
+++ b/src/__tests__/Slides.js
@@ -44,6 +44,10 @@ cases(
       url: 'https://team.slides.com/hakimel/finch/live',
       valid: false,
     },
+    'team Deck url with custom dotted team subdomain': {
+      url: 'https://dotted.team.slides.com/username/deck-name',
+      valid: false,
+    },
     'user embed url': {
       url: 'https://slides.com/kentcdodds/oss-we-want/embed',
       valid: false,
@@ -66,10 +70,6 @@ cases(
     },
     'team Deck url with custom hyphened team subdomain': {
       url: 'https://team-name.slides.com/username/deck-name',
-      valid: true,
-    },
-    'team Deck url with custom dotted team subdomain': {
-      url: 'https://dotted.team.slides.com/username/deck-name',
       valid: true,
     },
     'team Deck url with selected page': {

--- a/src/__tests__/Slides.js
+++ b/src/__tests__/Slides.js
@@ -48,6 +48,10 @@ cases(
       url: 'https://dotted.team.slides.com/username/deck-name',
       valid: false,
     },
+    'team Deck url with custom team subdomain of 1 character': {
+      url: 'https://a.slides.com/username/deck-name',
+      valid: false,
+    },
     'user embed url': {
       url: 'https://slides.com/kentcdodds/oss-we-want/embed',
       valid: false,
@@ -78,6 +82,10 @@ cases(
     },
     'team Deck url with custom alphanumeric team subdomain': {
       url: 'https://asdfdsa11232889ASD.slides.com/username/deck-name',
+      valid: true,
+    },
+    'team Deck url with custom team subdomain of 2 characters': {
+      url: 'https://ab.slides.com/username/deck-name',
       valid: true,
     },
     'team Deck url with selected page': {

--- a/src/__tests__/Slides.js
+++ b/src/__tests__/Slides.js
@@ -76,6 +76,10 @@ cases(
       url: 'https://team_name.slides.com/username/deck-name',
       valid: true,
     },
+    'team Deck url with custom alphanumeric team subdomain': {
+      url: 'https://asdfdsa11232889ASD.slides.com/username/deck-name',
+      valid: true,
+    },
     'team Deck url with selected page': {
       url: 'https://team.slides.com/hakimel/finch#/0',
       valid: true,


### PR DESCRIPTION
**What**:
Fix Slides transformer so that team Decks are properly supported.

**Why**:
Closes #36.
@hakimel (https://twitter.com/hakimel/status/1187010242514706432)
> Each team has their own custom subdomain

**How**:
Check if the `host` is a slides.com (sub)domain.

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [ ] Ready to be merged

---

Still waiting for @hakimel's [confirmation](https://twitter.com/MichaelDeBoey93/status/1187018779697565702) if custom subdomains can contain hyphens (`-`) and/or dots (`.`) before I'm going to merge this one.
> Yeah—subdomains can only consist of alphanumerics, underscore and hyphen. They have to be at least two characters long.