### PR TITLE
feat: add retry mechanism for network requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.6",
+    "fetch-retry": "^3.0.0",
     "node-fetch": "^2.6.0",
     "unist-util-visit": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.6",
-    "fetch-retry": "^3.0.0",
+    "fetch-retry": "^3.0.1",
     "node-fetch": "^2.6.0",
     "unist-util-visit": "^2.0.1"
   },

--- a/src/__tests__/transformers/utils/fetchOEmbedData.js
+++ b/src/__tests__/transformers/utils/fetchOEmbedData.js
@@ -1,0 +1,90 @@
+import fetch from 'node-fetch';
+import { fetchOEmbedData } from '../../../transformers/utils';
+
+const { Response } = jest.requireActual('node-fetch');
+
+jest.mock(`node-fetch`);
+
+// make timeouts quicker
+global.setTimeout = jest.fn(cb => {
+  setImmediate(cb);
+});
+
+describe(`fetchOEmbedData`, () => {
+  const URL = 'https://google.com';
+  const MockedResponseResult = { data: '12345' };
+
+  beforeEach(() => {
+    fetch.mockReset();
+    setTimeout.mockClear();
+  });
+
+  test(`returns promise resolving to object`, () => {
+    // make sure we make our result assertion
+    expect.assertions(4);
+
+    fetch.mockResolvedValue(new Response(JSON.stringify(MockedResponseResult)));
+
+    return fetchOEmbedData(URL).then(res => {
+      // assert some internal logic (that fetch was actually called)
+      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).nthCalledWith(1, URL, expect.anything());
+
+      // we didn't hit retry mechanism
+      expect(setTimeout).not.toBeCalled();
+      // assert actual result
+      expect(res).toEqual(MockedResponseResult);
+    });
+  });
+
+  describe(`network resilience`, () => {
+    test(`retries requests if there was network error`, () => {
+      // make sure we make our result assertion
+      expect.assertions(8);
+
+      // make first two calls throw an error and third call resolve
+      const socketError = new Error('socket hang up');
+      fetch
+        .mockRejectedValueOnce(socketError)
+        .mockRejectedValueOnce(socketError)
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(MockedResponseResult))
+        );
+
+      return fetchOEmbedData(URL).then(async res => {
+        // assert some internal logic (that fetch was actually called 3 times)
+        expect(fetch).toBeCalledTimes(3);
+        expect(fetch).nthCalledWith(1, URL, expect.anything());
+        expect(fetch).nthCalledWith(2, URL, expect.anything());
+        expect(fetch).nthCalledWith(3, URL, expect.anything());
+
+        // 2 retries
+        expect(setTimeout).toBeCalledTimes(2);
+
+        // make sure first two calls to real fetch did throw
+        await expect(fetch.mock.results[0].value).rejects.toEqual(socketError);
+        await expect(fetch.mock.results[1].value).rejects.toEqual(socketError);
+
+        expect(res).toEqual(MockedResponseResult);
+      });
+    });
+
+    test(`doesn't retry indefinitely`, () => {
+      // make sure we make our result assertion
+      expect.assertions(3);
+
+      const socketError = new Error('socket hang up');
+      fetch.mockRejectedValue(socketError);
+
+      return fetchOEmbedData(URL).catch(error => {
+        // original request + 3 retries
+        expect(fetch).toBeCalledTimes(4);
+
+        // 3 retries
+        expect(setTimeout).toBeCalledTimes(3);
+
+        expect(error).toEqual(socketError);
+      });
+    });
+  });
+});

--- a/src/__tests__/transformers/utils/fetchOEmbedData.js
+++ b/src/__tests__/transformers/utils/fetchOEmbedData.js
@@ -1,14 +1,11 @@
 import fetch from 'node-fetch';
+
 import { fetchOEmbedData } from '../../../transformers/utils';
 
 const { Response } = jest.requireActual('node-fetch');
-
 jest.mock(`node-fetch`);
-
 // make timeouts quicker
-global.setTimeout = jest.fn(cb => {
-  setImmediate(cb);
-});
+global.setTimeout = jest.fn(cb => setImmediate(cb));
 
 describe(`fetchOEmbedData`, () => {
   const URL = 'https://google.com';

--- a/src/transformers/utils/index.js
+++ b/src/transformers/utils/index.js
@@ -1,8 +1,7 @@
-import fetch from 'node-fetch';
 import wrapFetch from 'fetch-retry';
+import fetch from 'node-fetch';
 
 const fetchWithRetries = wrapFetch(fetch);
-
 export const fetchOEmbedData = url =>
   fetchWithRetries(url, {
     retries: 3,

--- a/src/transformers/utils/index.js
+++ b/src/transformers/utils/index.js
@@ -6,9 +6,7 @@ const fetchWithRetries = wrapFetch(fetch);
 export const fetchOEmbedData = url =>
   fetchWithRetries(url, {
     retries: 3,
-    retryDelay: attempt => {
-      return 2 ** attempt * 1000; // 1000, 2000, 4000
-    },
+    retryDelay: attempt => 2 ** attempt * 1000,
   }).then(data => data.json());
 
 export const getTrimmedPathName = pathname =>

--- a/src/transformers/utils/index.js
+++ b/src/transformers/utils/index.js
@@ -1,6 +1,15 @@
 import fetch from 'node-fetch';
+import wrapFetch from 'fetch-retry';
 
-export const fetchOEmbedData = url => fetch(url).then(data => data.json());
+const fetchWithRetries = wrapFetch(fetch);
+
+export const fetchOEmbedData = url =>
+  fetchWithRetries(url, {
+    retries: 3,
+    retryDelay: attempt => {
+      return 2 ** attempt * 1000; // 1000, 2000, 4000
+    },
+  }).then(data => data.json());
 
 export const getTrimmedPathName = pathname =>
   // Trim leading and trailing slashes


### PR DESCRIPTION
**What**:
This adds up to 3 retries for network requests if they happen to fail (with increasing timeouts between them). This aims to make the plugin more resilient and not to cause Gatsby build failures because of some network hiccups

**Why**:
Closes #74

In larger Gatsby sites there's often significant time cost to run `gatsby build` or `gatsby develop`. If this fails because of temporary network hiccup it leads to frustration and increases feedback loop time. Adding bit more robustness to network handling _should_ help to avoid those.

**How**:
By using [`fetch-retry`](https://www.npmjs.com/package/fetch-retry) wrapper around `node-fetch` with 3 retries and exponential back-off timeout for each consecutive retry.

**Checklist**:
- [N/A] Documentation
This feature should be transparent to plugin users (it doesn't require any configuration)
- [x] Tests
- [x] Ready to be merged