### PR TITLE
Import URL explicitly to work in node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: npm
 notifications:
   email: false
 node_js:
+  - '8'
   - '10'
   - '12'
 install: npm install

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import { URL } from 'url';
 import visit from 'unist-util-visit';
 
 import { defaultTransformers } from './transformers';
@@ -8,7 +9,11 @@ const getUrlString = url => {
   try {
     return new URL(urlString).toString();
   } catch (error) {
-    return null;
+    // if the error comes from an invalid link, suppress it
+    if (error instanceof TypeError) {
+      return null;
+    }
+    throw error;
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const getUrlString = url => {
     return new URL(urlString).toString();
   } catch (error) {
     // if the error comes from an invalid link, suppress it
-    if (error instanceof TypeError) {
+    if (error.code === 'ERR_INVALID_URL') {
       return null;
     }
     throw error;

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,7 @@ const getUrlString = url => {
   try {
     return new URL(urlString).toString();
   } catch (error) {
-    // if the error comes from an invalid link, suppress it
-    if (error.code === 'ERR_INVALID_URL') {
-      return null;
-    }
-    throw error;
+    return null;
   }
 };
 


### PR DESCRIPTION
**What**:
Import URL module explicitly. Fixes https://github.com/MichaelDeBoey/gatsby-remark-embedder/issues/61

**Why**:
In order to make the plugin work in Node 8.

**How**:
Apart from necessary import, I've added a condition in catch to suppress only TypeErrors (invalid links). It would make it easier to debug for those who are using old Node versions.

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
