### PR TITLE
Issue #85: 🐛  Fix bug that prevents childMarkdownRemark from being set

### DIFF
--- a/src/__tests__/__fixtures__/emptylink.md
+++ b/src/__tests__/__fixtures__/emptylink.md
@@ -1,0 +1,7 @@
+# Heading 1
+
+## Heading2
+
+This is a normal paragraph.
+
+[](https://example.com)

--- a/src/__tests__/__fixtures__/emptylink.md
+++ b/src/__tests__/__fixtures__/emptylink.md
@@ -1,7 +1,0 @@
-# Heading 1
-
-## Heading2
-
-This is a normal paragraph.
-
-[](https://example.com)

--- a/src/__tests__/__fixtures__/kitchensink.md
+++ b/src/__tests__/__fixtures__/kitchensink.md
@@ -4,7 +4,8 @@
 
 This is a normal paragraph.
 
-This is the first line of a multi-line paragraph. And this is the second line.
+This is the first line of a multi-line paragraph.  
+And this is the second line.
 
 This is a paragraph with a [link](https://example.com).
 
@@ -13,6 +14,8 @@ This is a paragraph with a [link](https://example.com).
 [https://example.com](https://example.com 'A link to example.com')
 
 <https://example.com>
+
+[](https://example.com)
 
 https://codepen.io/team/codepen/pen/PNaGbb
 

--- a/src/__tests__/__fixtures__/kitchensink.md
+++ b/src/__tests__/__fixtures__/kitchensink.md
@@ -4,8 +4,7 @@
 
 This is a normal paragraph.
 
-This is the first line of a multi-line paragraph.  
-And this is the second line.
+This is the first line of a multi-line paragraph. And this is the second line.
 
 This is a paragraph with a [link](https://example.com).
 

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -30,7 +30,7 @@ describe('gatsby-remark-embedder', () => {
 
       This is a normal paragraph.
 
-      This is the first line of a multi-line paragraph.
+      This is the first line of a multi-line paragraph.  
       And this is the second line.
 
       This is a paragraph with a [link](https://example.com).
@@ -40,6 +40,8 @@ describe('gatsby-remark-embedder', () => {
       [https://example.com](https://example.com \\"A link to example.com\\")
 
       <https://example.com>
+
+      [](https://example.com)
 
       <iframe src=\\"https://codepen.io/team/codepen/embed/preview/PNaGbb\\" style=\\"width:100%; height:300px;\\"></iframe>
 
@@ -62,23 +64,6 @@ describe('gatsby-remark-embedder', () => {
       <blockquote class=\\"twitter-tweet-from-cache\\"><p lang=\\"en\\" dir=\\"ltr\\">example</p>&mdash; Kent C. Dodds (@kentcdodds) <a href=\\"https://twitter.com/kentcdodds/status/1078755736455278592\\">December 28, 2018</a></blockquote>
 
       <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
-      "
-    `);
-  });
-
-  test('can transform a link with no label (emptylink)', async () => {
-    const markdownAST = getMarkdownASTForFile('emptylink', true);
-
-    const processedAST = await plugin({ cache, markdownAST });
-
-    expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-      "# Heading 1
-
-      ## Heading2
-
-      This is a normal paragraph.
-
-      [](https://example.com)
       "
     `);
   });

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -30,7 +30,7 @@ describe('gatsby-remark-embedder', () => {
 
       This is a normal paragraph.
 
-      This is the first line of a multi-line paragraph.  
+      This is the first line of a multi-line paragraph.
       And this is the second line.
 
       This is a paragraph with a [link](https://example.com).
@@ -62,6 +62,23 @@ describe('gatsby-remark-embedder', () => {
       <blockquote class=\\"twitter-tweet-from-cache\\"><p lang=\\"en\\" dir=\\"ltr\\">example</p>&mdash; Kent C. Dodds (@kentcdodds) <a href=\\"https://twitter.com/kentcdodds/status/1078755736455278592\\">December 28, 2018</a></blockquote>
 
       <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
+      "
+    `);
+  });
+
+  test('can transform a link with no label (emptylink)', async () => {
+    const markdownAST = getMarkdownASTForFile('emptylink', true);
+
+    const processedAST = await plugin({ cache, markdownAST });
+
+    expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
+      "# Heading 1
+
+      ## Heading2
+
+      This is a normal paragraph.
+
+      [](https://example.com)
       "
     `);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default async (
     const isValidLink =
       node.type === 'link' &&
       node.title === null &&
-      node.children[0] &&
+      node.children.length === 1 &&
       node.children[0].value === node.url;
     if (!isText && !isValidLink) {
       return;

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ export default async (
     const isValidLink =
       node.type === 'link' &&
       node.title === null &&
+      node.children[0] &&
       node.children[0].value === node.url;
     if (!isText && !isValidLink) {
       return;


### PR DESCRIPTION
**What**:
Closes #85 

**Why**:
If the change isn't made there is a particular link format that can keep the entire markdown document from being rendered.

**How**:
Added an extra check in the isValid link code.

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Ready to be merged