### PR TITLE
feat(fetchOEmbedData): Handle non-ok responses

### DIFF
--- a/src/__tests__/transformers/GIPHY.js
+++ b/src/__tests__/transformers/GIPHY.js
@@ -11,12 +11,13 @@ import {
 
 import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
 
+const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
 
 const mockFetch = ({ height, width }) =>
-  fetchMock.mockResolvedValue({
-    json: () => Promise.resolve({ height, width }),
-  });
+  fetchMock.mockImplementation(() =>
+    Promise.resolve(new Response(JSON.stringify({ height, width })))
+  );
 
 beforeEach(() => {
   fetchMock.mockClear();

--- a/src/__tests__/transformers/Instagram.js
+++ b/src/__tests__/transformers/Instagram.js
@@ -6,10 +6,13 @@ import { getHTML, shouldTransform } from '../../transformers/Instagram';
 
 import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
 
+const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
 
 const mockFetch = html =>
-  fetchMock.mockResolvedValue({ json: () => Promise.resolve({ html }) });
+  fetchMock.mockImplementation(() =>
+    Promise.resolve(new Response(JSON.stringify({ html })))
+  );
 
 beforeEach(() => {
   fetchMock.mockClear();

--- a/src/__tests__/transformers/Streamable.js
+++ b/src/__tests__/transformers/Streamable.js
@@ -10,10 +10,13 @@ import {
 
 import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
 
+const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
 
 const mockFetch = html =>
-  fetchMock.mockResolvedValue({ json: () => Promise.resolve({ html }) });
+  fetchMock.mockImplementation(() =>
+    Promise.resolve(new Response(JSON.stringify({ html })))
+  );
 
 beforeEach(() => {
   fetchMock.mockClear();

--- a/src/__tests__/transformers/Twitter.js
+++ b/src/__tests__/transformers/Twitter.js
@@ -6,16 +6,17 @@ import { getHTML, shouldTransform } from '../../transformers/Twitter';
 
 import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
 
+const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
 
 const mockFetch = (status, moment) =>
   fetchMock
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ html: status }) })
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ html: status }) })
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ html: moment }) })
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ html: moment }) })
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ html: moment }) })
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ html: moment }) });
+    .mockResolvedValueOnce(new Response(JSON.stringify({ html: status })))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ html: status })))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ html: moment })))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ html: moment })))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ html: moment })))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ html: moment })));
 
 beforeEach(() => {
   fetchMock.mockReset();

--- a/src/__tests__/transformers/utils/fetchOEmbedData.js
+++ b/src/__tests__/transformers/utils/fetchOEmbedData.js
@@ -34,6 +34,25 @@ describe(`fetchOEmbedData`, () => {
     });
   });
 
+  test(`throws on non-ok status`, () => {
+    // make sure we make our result assertion
+    expect.assertions(1);
+
+    fetch.mockResolvedValue(
+      new Response(JSON.stringify(MockedResponseResult), {
+        // non-ok status is one outside of 200-299 range
+        // ( https://developer.mozilla.org/en-US/docs/Web/API/Response/ok )
+        status: 403,
+      })
+    );
+
+    return fetchOEmbedData(URL).catch(err => {
+      expect(err).toMatchInlineSnapshot(
+        `[Error: Request to https://google.com returned non-OK status (403)]`
+      );
+    });
+  });
+
   describe(`network resilience`, () => {
     test(`retries requests if there was network error`, () => {
       // make sure we make our result assertion

--- a/src/transformers/utils/index.js
+++ b/src/transformers/utils/index.js
@@ -6,7 +6,17 @@ export const fetchOEmbedData = url =>
   fetchWithRetries(url, {
     retries: 3,
     retryDelay: attempt => 2 ** attempt * 1000,
-  }).then(data => data.json());
+  })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(
+          `Request to ${url} returned non-OK status (${response.status})`
+        );
+      }
+
+      return response;
+    })
+    .then(data => data.json());
 
 export const getTrimmedPathName = pathname =>
   // Trim leading and trailing slashes


### PR DESCRIPTION
**What**:

Check OEmbed response status and throw if it's not `ok` (200-299 status range)

**Why**:

Because plugin currently doesn't handle case of non-ok response and have potential to throw very confusing errors that are hard to track down to root cause. Having explicit handling allow us to throw actionable errors (by pointing which links are problematic)

**How**:

Adding check for `response.ok` and throwing if it's falsy.

The change also added need to do some changes to existing tests, where I changed mocks to use actual `Response` object instead of fully mocked object (instead of adding `ok` and `status` there).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation 
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Closes #99 
Closes #103