### PR TITLE
chore: Use global URL instead of imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import visit from 'unist-util-visit';
 
 import { defaultTransformers } from './transformers';

--- a/src/transformers/CodePen.js
+++ b/src/transformers/CodePen.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 export const shouldTransform = (url) => {
   const { host, pathname } = new URL(url);
 

--- a/src/transformers/CodeSandbox.js
+++ b/src/transformers/CodeSandbox.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 export const shouldTransform = (url) => {
   const { host, pathname } = new URL(url);
 

--- a/src/transformers/GIPHY.js
+++ b/src/transformers/GIPHY.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 import { fetchOEmbedData } from './utils';
 
 const isMediaSubDomain = (host) => /^(media([0-9]+)?\.)giphy\.com$/.test(host);

--- a/src/transformers/Instagram.js
+++ b/src/transformers/Instagram.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 import { fetchOEmbedData } from './utils';
 
 export const shouldTransform = (url) => {

--- a/src/transformers/Lichess.js
+++ b/src/transformers/Lichess.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 import { includesSomeOfArray } from './utils';
 
 export const shouldTransform = (url) => {

--- a/src/transformers/Pinterest.js
+++ b/src/transformers/Pinterest.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 import { getTrimmedPathName } from './utils';
 
 const isBoard = (trimmedPathName) => trimmedPathName.split('/').length === 2;

--- a/src/transformers/Slides.js
+++ b/src/transformers/Slides.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 import { getTrimmedPathName } from './utils';
 
 const isSubDomain = (host) => /^([a-zA-Z0-9-_]{2,}\.)?slides\.com$/.test(host);

--- a/src/transformers/SoundCloud.js
+++ b/src/transformers/SoundCloud.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 export const shouldTransform = (url) => new URL(url).host === 'soundcloud.com';
 
 const getSoundCloudIFrameSrc = (url) =>

--- a/src/transformers/Spotify.js
+++ b/src/transformers/Spotify.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 import { includesSomeOfArray } from './utils';
 
 export const shouldTransform = (url) => {

--- a/src/transformers/Streamable.js
+++ b/src/transformers/Streamable.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 import { fetchOEmbedData, getTrimmedPathName } from './utils';
 
 const ignoredPaths = [

--- a/src/transformers/Twitch.js
+++ b/src/transformers/Twitch.js
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import { getTrimmedPathName } from './utils';
 
 const getUrlConfig = (url) => {

--- a/src/transformers/Twitter.js
+++ b/src/transformers/Twitter.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 import { fetchOEmbedData, includesSomeOfArray } from './utils';
 
 export const shouldTransform = (url) => {

--- a/src/transformers/YouTube.js
+++ b/src/transformers/YouTube.js
@@ -1,5 +1,3 @@
-import { URL } from 'url';
-
 export const shouldTransform = (url) => {
   const { host, pathname, searchParams } = new URL(url);
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Removed support for Node v8 and Removed URL imports

**Why**:
  
https://github.com/MichaelDeBoey/gatsby-remark-embedder/issues/82
  
<!-- How were these changes implemented? -->

**How**:

Replaced all in VSCode

<!-- Have you done all of these things?  -->
yes, Will wait for test
**Checklist**:

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Please Squash and merge if working.