### PR TITLE
Add support for YouTube channels, fixes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,11 +687,12 @@ https://twitter.com/wesbos/timelines/1189618481672667136
 
 ### YouTube
 
-The YouTube transformer (currently) only supports videos in the following
-formats:
+The YouTube transformer (currently) supports videos and channels in the
+following formats:
 
 - Full url (`https://youtube.com/watch?v=dQw4w9WgXcQ`)
 - Short url (`https://youtu.be/dQw4w9WgXcQ`)
+- Channel url (`https://youtube.com/user/kentdoddsfamily`)
 
 #### Usage
 

--- a/src/__tests__/transformers/YouTube.js
+++ b/src/__tests__/transformers/YouTube.js
@@ -67,7 +67,7 @@ cases(
     },
     'user full url': {
       url: 'https://youtube.com/user/kentdoddsfamily',
-      valid: false,
+      valid: true,
     },
     'user short url': {
       url: 'https://youtube.com/kentdoddsfamily',
@@ -175,7 +175,7 @@ test('Plugin can transform YouTube links', async () => {
 
     <https://youtube.com/playlist?list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u>
 
-    <https://youtube.com/user/kentdoddsfamily>
+    <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube.com/embed?listType=user_uploads&list=kentdoddsfamily\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
 
     <https://youtube.com/kentdoddsfamily>
     "

--- a/src/transformers/YouTube.js
+++ b/src/transformers/YouTube.js
@@ -4,9 +4,8 @@ export const shouldTransform = (url) => {
   return (
     host === 'youtu.be' ||
     (['youtube.com', 'www.youtube.com'].includes(host) &&
-      pathname.includes('/watch') &&
-      Boolean(searchParams.get('v'))) ||
-    pathname.includes('/user/')
+      ((pathname.includes('/watch') && Boolean(searchParams.get('v'))) ||
+        pathname.includes('/user/')))
   );
 };
 

--- a/src/transformers/YouTube.js
+++ b/src/transformers/YouTube.js
@@ -5,7 +5,8 @@ export const shouldTransform = (url) => {
     host === 'youtu.be' ||
     (['youtube.com', 'www.youtube.com'].includes(host) &&
       pathname.includes('/watch') &&
-      Boolean(searchParams.get('v')))
+      Boolean(searchParams.get('v'))) ||
+    pathname.includes('/user/')
   );
 };
 
@@ -24,6 +25,13 @@ export const getTimeValueInSeconds = (timeValue) => {
 };
 export const getYouTubeIFrameSrc = (urlString) => {
   const url = new URL(urlString);
+  if (urlString.includes('/user/')) {
+    const channelID = urlString.split('/user/')[1];
+    const channelEmbed =
+      'https://www.youtube.com/embed?listType=user_uploads&list=';
+    return channelEmbed + channelID;
+  }
+
   let id = url.searchParams.get('v');
   if (url.host === 'youtu.be') {
     id = url.pathname.slice(1);


### PR DESCRIPTION
**What**: Added support for YouTube channels of the type `https://youtube.com/user/kentdoddsfamily`.

**Why**: Closes #13

**How**: Per [YouTube Docs](https://developers.google.com/youtube/player_parameters)

**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Ready to be merged

## Caveat
I went through some of the channels:
+ https://www.youtube.com/user/1agastya
+ https://www.youtube.com/user/kentdoddsfamily
+ https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw
+ https://www.youtube.com/user/taylorswift
+ https://www.youtube.com/user/PewDiePie
+ https://www.youtube.com/user/tseries

All but "Official Rick Astley" had their channels of the type "youtube.com/user/" -- I don't know why that one channel has a different format -- it can not be subscribers count because T-Series and Pewdiepie has the maximum count.  The docs (linked above) mentions `https://www.youtube.com/embed?listType=user_uploads&list=**USERNAME**` for this solution.

This is one caveat one needs to be aware of.