### PR TITLE
feat: allow overriding default transformers with same name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,15 @@ export default async (
   { cache, markdownAST },
   { customTransformers = [], services = {} } = {}
 ) => {
-  const transformers = [...defaultTransformers, ...customTransformers];
+  const customTransformerNames = customTransformers
+    .map(({ name }) => name?.toLowerCase())
+    .filter(Boolean);
+
+  const filteredDefaultTransformers = defaultTransformers.filter(
+    ({ name }) => !customTransformerNames.includes(name?.toLowerCase())
+  );
+
+  const transformers = [...filteredDefaultTransformers, ...customTransformers];
 
   const transformations = [];
   visit(markdownAST, 'paragraph', (paragraphNode) => {

--- a/src/transformers/CodePen.js
+++ b/src/transformers/CodePen.js
@@ -12,3 +12,5 @@ export const getHTML = (url) => {
 
   return `<iframe src="${iframeUrl}" style="width:100%; height:300px;"></iframe>`;
 };
+
+export const name = 'CodePen';

--- a/src/transformers/CodeSandbox.js
+++ b/src/transformers/CodeSandbox.js
@@ -12,3 +12,5 @@ export const getHTML = (url) => {
 
   return `<iframe src="${iframeUrl}" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"></iframe>`;
 };
+
+export const name = 'CodeSandbox';

--- a/src/transformers/GIPHY.js
+++ b/src/transformers/GIPHY.js
@@ -34,3 +34,5 @@ export const getHTML = (url) =>
       return `<div style="width:100%;height:0;padding-bottom:${padding}%;position:relative;"><iframe src="https://giphy.com/embed/${GIPHYId}" width="100%" height="100%" style="position:absolute" frameborder="0" class="giphy-embed" allowfullscreen></iframe></div>`;
     }
   );
+
+export const name = 'GIPHY';

--- a/src/transformers/Instagram.js
+++ b/src/transformers/Instagram.js
@@ -17,3 +17,5 @@ export const getHTML = (url) =>
   fetchOEmbedData(
     `https://api.instagram.com/oembed?url=${url}&omitscript=true`
   ).then(({ html }) => html);
+
+export const name = 'Instagram';

--- a/src/transformers/Lichess.js
+++ b/src/transformers/Lichess.js
@@ -22,3 +22,5 @@ export const getHTML = (url) => {
 
   return `<iframe src="${iframeUrl}" width="600" height="397" frameborder="0"></iframe>`;
 };
+
+export const name = 'Lichess';

--- a/src/transformers/Pinterest.js
+++ b/src/transformers/Pinterest.js
@@ -30,3 +30,5 @@ export const getHTML = (url) => {
 
   return `<a data-pin-do="embedUser" data-pin-board-width="400" data-pin-scale-height="240" data-pin-scale-width="80" href="${url}"></a>`;
 };
+
+export const name = 'Pinterest';

--- a/src/transformers/Slides.js
+++ b/src/transformers/Slides.js
@@ -23,3 +23,5 @@ export const getHTML = (url) => {
 
   return `<iframe src="${iframeSrc}" width="576" height="420" scrolling="no" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>`;
 };
+
+export const name = 'Slides';

--- a/src/transformers/SoundCloud.js
+++ b/src/transformers/SoundCloud.js
@@ -8,3 +8,5 @@ export const getHTML = (url) => {
 
   return `<iframe width="100%" height="300" scrolling="no" frameborder="no" src=${iframeUrl}></iframe>`;
 };
+
+export const name = 'SoundCloud';

--- a/src/transformers/Spotify.js
+++ b/src/transformers/Spotify.js
@@ -34,3 +34,5 @@ export const getHTML = (url) => {
 
   return `<iframe src="${iframeSrc}" width="100%" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>`;
 };
+
+export const name = 'Spotify';

--- a/src/transformers/Streamable.js
+++ b/src/transformers/Streamable.js
@@ -39,3 +39,5 @@ export const getHTML = (url) => {
     `https://api.streamable.com/oembed.json?url=${normalizedUrl}`
   ).then(({ html }) => html);
 };
+
+export const name = 'Streamable';

--- a/src/transformers/Twitter.js
+++ b/src/transformers/Twitter.js
@@ -6,7 +6,11 @@ export const shouldTransform = (url) => {
   return (
     ['twitter.com', 'www.twitter.com'].includes(host) &&
     (pathname.includes('/status/') ||
-      (includesSomeOfArray(pathname, ['/events/', '/moments/', '/timelines/']) &&
+      (includesSomeOfArray(pathname, [
+        '/events/',
+        '/moments/',
+        '/timelines/',
+      ]) &&
         !pathname.includes('/edit/')))
   );
 };
@@ -28,3 +32,5 @@ export const getHTML = (url) => {
       .trim()
   );
 };
+
+export const name = 'Twitter';

--- a/src/transformers/YouTube.js
+++ b/src/transformers/YouTube.js
@@ -50,3 +50,5 @@ export const getHTML = (url) => {
 
   return `<iframe width="100%" height="315" src="${iframeSrc}" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>`;
 };
+
+export const name = 'YouTube';


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Override the default transformer when a custom transformer with the same name exists

<!-- Why are these changes necessary? -->

**Why**: I wanted to override the default Twitter transformer with my own to make changes to the oembed API call but because a default transformer exists for it, it ignores the custom transformer

<!-- How were these changes implemented? -->

**How**: 
1. Create an array of `customTransformerNames` which stores all the names of user-created transformers
2. Filter out the default transformers who's name matches the ones created by the user

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Wanted to get some early feedback if this is the right approach or if there's an alternative so that I can go ahead with writing the documentation and tests