### PR TITLE
feat(CodePen): Add support for height & width options

### DIFF
--- a/src/__tests__/transformers/CodePen.js
+++ b/src/__tests__/transformers/CodePen.js
@@ -1,8 +1,6 @@
 import cases from 'jest-in-case';
-
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/CodePen';
-
 import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
@@ -79,10 +77,21 @@ cases(
 );
 
 test('Gets the correct CodePen iframe', () => {
-  const html = getHTML('https://codepen.io/team/codepen/pen/PNaGbb');
+  const html = getHTML('https://codepen.io/team/codepen/pen/PNaGbb', {});
 
   expect(html).toMatchInlineSnapshot(
     `<iframe src="https://codepen.io/team/codepen/embed/preview/PNaGbb" style="width:100%; height:300px;"></iframe>`
+  );
+});
+
+test('Gets the correct CodePen iframe with custom dimensions', () => {
+  const html = getHTML('https://codepen.io/team/codepen/pen/PNaGbb', {
+    width: '50%',
+    height: '50%',
+  });
+
+  expect(html).toMatchInlineSnapshot(
+    `<iframe src="https://codepen.io/team/codepen/embed/preview/PNaGbb" style="width:50%; height:50%;"></iframe>`
   );
 });
 

--- a/src/transformers/CodePen.js
+++ b/src/transformers/CodePen.js
@@ -7,8 +7,8 @@ export const shouldTransform = (url) => {
   );
 };
 
-export const getHTML = (url) => {
+export const getHTML = (url, { width = '100%', height = '300px' }) => {
   const iframeUrl = url.replace('/pen/', '/embed/preview/');
 
-  return `<iframe src="${iframeUrl}" style="width:100%; height:300px;"></iframe>`;
+  return `<iframe src="${iframeUrl}" style="width:${width}; height:${height};"></iframe>`;
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Added option to override hardcoded CodePen dimensions, with option to merge provided options with default options

<!-- Why are these changes necessary? -->

**Why**: In order to change hardcoded CodePen's iframe width/height

<!-- How were these changes implemented? -->

**How**:

Each transformer can optionally export a `const defaultOptions`. 
When the plugin runs it merges provided options ( `services[name]`) if exist with `defaultOptions` with precedence of provided options, and passes them as a second argument to the transformer exported `getHTML` function
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
