### PR TITLE
feat: export a non-gatsby remark plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: './node_modules/kcd-scripts/eslint.js',
+  rules: {
+    'no-continue': 'off',
+  },
 };

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ gif/pen/pin/player/playground/post/sandbox/tweet/video you want to embed right
 from within your browser onto a separate line (surrounded by empty lines) and
 replace it with the proper embed-code.
 
+It also exports a remark plugin directly. Read more about how to use that below.
+
 ## Table of Contents
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -62,6 +64,7 @@ replace it with the proper embed-code.
 - [Options](#options)
   - [customTransformers](#customtransformers)
   - [services](#services)
+- [Remark plugin](#remark-plugin)
 - [Inspiration](#inspiration)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
@@ -816,6 +819,32 @@ The plugin also allows you to pass an object which keys that represent the name
 of the [service](#supported-services) to transform and the value that's an
 object with options for that specific service.
 
+## Remark plugin
+
+If you want to use this directly with remark (without gatsby), here's an example
+of doing that:
+
+```javascript
+const remark = require('remark');
+const { remarkEmbedder } = require('gatsby-remark-embedder');
+
+const exampleMarkdown = `
+This is a great video:
+
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+`;
+
+const result = await remark()
+  .use(remarkEmbedder, {
+    customTransformers: [
+      // Your custom transformers
+    ],
+  })
+  .process(exampleMarkdown);
+
+// result.toString() <-- that's got the embed HTML
+```
+
 ## Inspiration
 
 This whole plugin was extracted out of Kent C. Dodds' [personal
@@ -884,6 +913,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ https://soundcloud.com/clemenswenners/africa
   height="300"
   scrolling="no"
   frameborder="no"
-  src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true
+  src="https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true"
 ></iframe>
 ```
 
@@ -826,7 +826,8 @@ of doing that:
 
 ```javascript
 import remark from 'remark';
-import remarkEmbedder 'gatsby-remark-embedder';
+import remarkEmbedder from 'gatsby-remark-embedder';
+import remarkHtml from 'remark-html';
 
 const exampleMarkdown = `
 This is a great video:
@@ -840,6 +841,7 @@ const result = await remark()
       // Your custom transformers
     ],
   })
+  .use(remarkHtml)
   .process(exampleMarkdown);
 
 // result.toString() <-- that's got the embed HTML

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ module.exports = {
       options: {
         plugins: [
           {
-            resolve: `gatsby-remark-embedder`,
+            resolve: `gatsby-remark-embedder/gatsby`,
             options: {
               customTransformers: [
                 // Your custom transformers
@@ -143,7 +143,7 @@ module.exports = {
       options: {
         gatsbyRemarkPlugins: [
           {
-            resolve: `gatsby-remark-embedder`,
+            resolve: `gatsby-remark-embedder/gatsby`,
             options: {
               customTransformers: [
                 // Your custom transformers
@@ -825,8 +825,8 @@ If you want to use this directly with remark (without gatsby), here's an example
 of doing that:
 
 ```javascript
-const remark = require('remark');
-const { remarkEmbedder } = require('gatsby-remark-embedder');
+import remark from 'remark';
+import remarkEmbedder 'gatsby-remark-embedder';
 
 const exampleMarkdown = `
 This is a great video:

--- a/gatsby.js
+++ b/gatsby.js
@@ -1,0 +1,1 @@
+module.exports = require('to-gatsby-remark-plugin')(require('.'));

--- a/package.json
+++ b/package.json
@@ -61,9 +61,6 @@
     "remark": "^13.0.0",
     "remark-html": "^13.0.1"
   },
-  "peerDependencies": {
-    "gatsby": "^2.20.0"
-  },
   "engines": {
     "node": ">=10.13.0",
     "npm": ">=6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "homepage": "https://github.com/MichaelDeBoey/gatsby-remark-embedder#readme",
   "files": [
-    "dist"
+    "dist",
+    "gatsby.js"
   ],
   "scripts": {
     "build": "kcd-scripts build",
@@ -52,6 +53,7 @@
     "hast-util-from-parse5": "^6.0.1",
     "node-fetch": "^2.6.1",
     "parse5": "^6.0.1",
+    "to-gatsby-remark-plugin": "^0.1.0",
     "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {

--- a/src/__tests__/CustomTransformer.js
+++ b/src/__tests__/CustomTransformer.js
@@ -10,10 +10,10 @@ const transformer = {
 test('Plugin can transform CustomTransformer links', async () => {
   const markdownAST = getMarkdownASTForFile('CustomTransformer', true);
 
-  const processedAST = await plugin(
-    { cache, markdownAST },
-    { customTransformers: [transformer] }
-  );
+  const processedAST = await plugin({
+    cache,
+    customTransformers: [transformer],
+  })(markdownAST);
 
   expect(transformer.shouldTransform).toHaveBeenCalledTimes(2);
   expect(transformer.shouldTransform).toHaveBeenCalledWith(

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -23,19 +23,17 @@ describe('gatsby-remark-embedder', () => {
     });
     const markdownAST = getMarkdownASTForFile('kitchensink', true);
 
-    const processedAST = await plugin(
-      { cache, markdownAST },
-      {
-        services: {
-          Instagram: {
-            accessToken: 'access-token',
-          },
-          Twitch: {
-            parent: 'embed.example.com',
-          },
+    const processedAST = await plugin({
+      cache,
+      services: {
+        Instagram: {
+          accessToken: 'access-token',
         },
-      }
-    );
+        Twitch: {
+          parent: 'embed.example.com',
+        },
+      },
+    })(markdownAST);
 
     expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
       <h1>Heading 1</h1>
@@ -77,12 +75,12 @@ describe('gatsby-remark-embedder', () => {
     const markdownAST = getMarkdownASTForFile('ErrorTransformer', true);
 
     await expect(
-      plugin({ cache, markdownAST }, { customTransformers: [errorTransformer] })
+      plugin({ customTransformers: [errorTransformer] })(markdownAST)
     ).rejects.toMatchInlineSnapshot(`
-            [Error: The following error appeared while processing 'https://error-site.com/':
+      [Error: The following error appeared while processing 'https://error-site.com/':
 
-            An error occurred in ErrorTransformer]
-          `);
+      An error occurred in ErrorTransformer]
+    `);
   });
 
   cases(
@@ -96,13 +94,10 @@ describe('gatsby-remark-embedder', () => {
 
       const markdownAST = getMarkdownASTForFile('ServiceTransformer', true);
 
-      await plugin(
-        { cache, markdownAST },
-        {
-          customTransformers: [transformer],
-          services: { serviceTransformer: { service: 'transformer' } },
-        }
-      );
+      await plugin({
+        customTransformers: [transformer],
+        services: { serviceTransformer: { service: 'transformer' } },
+      })(markdownAST);
 
       expect(transformer.getHTML).toHaveBeenCalledWith(
         'https://some-site.com/id/abc',

--- a/src/__tests__/remark.js
+++ b/src/__tests__/remark.js
@@ -11,3 +11,16 @@ test('works with remark directly', async () => {
     "
   `);
 });
+
+test('can pass options', async () => {
+  const myCache = new Map();
+  await remark()
+    .use(remarkEmbedder, { cache: myCache })
+    .process('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+  expect(myCache).toMatchInlineSnapshot(`
+    Map {
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ" => "<iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>",
+    }
+  `);
+});

--- a/src/__tests__/remark.js
+++ b/src/__tests__/remark.js
@@ -1,5 +1,5 @@
 import remark from 'remark';
-import { remarkEmbedder } from '../';
+import remarkEmbedder from '../';
 
 test('works with remark directly', async () => {
   const result = await remark()
@@ -7,8 +7,7 @@ test('works with remark directly', async () => {
     .process('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 
   expect(result.toString()).toMatchInlineSnapshot(`
-    "<iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
-    "
+    <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
   `);
 });
 
@@ -20,7 +19,7 @@ test('can pass options', async () => {
 
   expect(myCache).toMatchInlineSnapshot(`
     Map {
-      "https://www.youtube.com/watch?v=dQw4w9WgXcQ" => "<iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>",
+      https://www.youtube.com/watch?v=dQw4w9WgXcQ => <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>,
     }
   `);
 });

--- a/src/__tests__/remark.js
+++ b/src/__tests__/remark.js
@@ -1,0 +1,13 @@
+import remark from 'remark';
+import { remarkEmbedder } from '../';
+
+test('works with remark directly', async () => {
+  const result = await remark()
+    .use(remarkEmbedder)
+    .process('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+  expect(result.toString()).toMatchInlineSnapshot(`
+    "<iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
+    "
+  `);
+});

--- a/src/__tests__/remark.js
+++ b/src/__tests__/remark.js
@@ -1,13 +1,16 @@
 import remark from 'remark';
+import html from 'remark-html';
 import remarkEmbedder from '../';
 
 test('works with remark directly', async () => {
   const result = await remark()
     .use(remarkEmbedder)
+    .use(html)
     .process('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 
   expect(result.toString()).toMatchInlineSnapshot(`
-    <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
+    <iframe width="100%" height="315" src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
   `);
 });
 
@@ -15,6 +18,7 @@ test('can pass options', async () => {
   const myCache = new Map();
   await remark()
     .use(remarkEmbedder, { cache: myCache })
+    .use(html)
     .process('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 
   expect(myCache).toMatchInlineSnapshot(`

--- a/src/__tests__/transformers/CodePen.js
+++ b/src/__tests__/transformers/CodePen.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/CodePen';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -89,7 +89,7 @@ test('Gets the correct CodePen iframe', () => {
 test('Plugin can transform CodePen links', async () => {
   const markdownAST = getMarkdownASTForFile('CodePen');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-codepen-url.com</p>

--- a/src/__tests__/transformers/CodeSandbox.js
+++ b/src/__tests__/transformers/CodeSandbox.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/CodeSandbox';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -53,7 +53,7 @@ test('Gets the correct CodeSandbox iframe', () => {
 test('Plugin can transform CodeSandbox links', async () => {
   const markdownAST = getMarkdownASTForFile('CodeSandbox');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-codesandbox-url.com</p>

--- a/src/__tests__/transformers/GIPHY.js
+++ b/src/__tests__/transformers/GIPHY.js
@@ -9,7 +9,7 @@ import {
   shouldTransform,
 } from '../../transformers/GIPHY';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
@@ -141,7 +141,7 @@ test('Plugin can transform GIPHY links', async () => {
 
   const markdownAST = getMarkdownASTForFile('GIPHY');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-giphy-url.com</p>

--- a/src/__tests__/transformers/Instagram.js
+++ b/src/__tests__/transformers/Instagram.js
@@ -4,7 +4,7 @@ import fetchMock from 'node-fetch';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/Instagram';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
@@ -119,16 +119,13 @@ test('Plugin can transform Instagram links', async () => {
   );
   const markdownAST = getMarkdownASTForFile('Instagram');
 
-  const processedAST = await plugin(
-    { cache, markdownAST },
-    {
-      services: {
-        Instagram: {
-          accessToken: 'access-token',
-        },
+  const processedAST = await plugin({
+    services: {
+      Instagram: {
+        accessToken: 'access-token',
       },
-    }
-  );
+    },
+  })(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-an-instagram-url.com</p>

--- a/src/__tests__/transformers/Lichess.js
+++ b/src/__tests__/transformers/Lichess.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/Lichess';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -93,7 +93,7 @@ test('Gets the correct Lichess iframe', () => {
 test('Plugin can transform Lichess links', async () => {
   const markdownAST = getMarkdownASTForFile('Lichess');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-lichess-url.org</p>

--- a/src/__tests__/transformers/Pinterest.js
+++ b/src/__tests__/transformers/Pinterest.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../..';
 import { getHTML, shouldTransform } from '../../transformers/Pinterest';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -77,7 +77,7 @@ test('Gets the correct Pinterest profile link', () => {
 test('Plugin can transform Pinterest links', async () => {
   const markdownAST = getMarkdownASTForFile('Pinterest');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-pinterest-url.com</p>

--- a/src/__tests__/transformers/Slides.js
+++ b/src/__tests__/transformers/Slides.js
@@ -7,7 +7,7 @@ import {
   shouldTransform,
 } from '../../transformers/Slides';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -218,7 +218,7 @@ test('Gets the correct Slides iframe', () => {
 test('Plugin can transform Slides links', async () => {
   const markdownAST = getMarkdownASTForFile('Slides');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-slides-url.com</p>

--- a/src/__tests__/transformers/SoundCloud.js
+++ b/src/__tests__/transformers/SoundCloud.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/SoundCloud';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -54,7 +54,7 @@ test('Gets the correct SoundCloud iframe', async () => {
 test('Plugin can transform SoundCloud links', async () => {
   const markdownAST = getMarkdownASTForFile('SoundCloud');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-soundcloud-url.com</p>

--- a/src/__tests__/transformers/Spotify.js
+++ b/src/__tests__/transformers/Spotify.js
@@ -7,7 +7,7 @@ import {
   shouldTransform,
 } from '../../transformers/Spotify';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -125,7 +125,7 @@ test('Gets the correct Spotify iframe', () => {
 test('Plugin can transform Spotify links', async () => {
   const markdownAST = getMarkdownASTForFile('Spotify');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-spotify-url.com</p>

--- a/src/__tests__/transformers/Streamable.js
+++ b/src/__tests__/transformers/Streamable.js
@@ -8,7 +8,7 @@ import {
   shouldTransform,
 } from '../../transformers/Streamable';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
@@ -193,7 +193,7 @@ test('Plugin correctly transforms Streamable links', async () => {
   );
   const markdownAST = getMarkdownASTForFile('Streamable');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-streamable-url.com</p>

--- a/src/__tests__/transformers/TestingPlayground.js
+++ b/src/__tests__/transformers/TestingPlayground.js
@@ -7,7 +7,7 @@ import {
   shouldTransform,
 } from '../../transformers/TestingPlayground';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -95,7 +95,7 @@ test('Gets the correct Testing Playground iframe', () => {
 test('Plugin can transform Testing Playground links', async () => {
   const markdownAST = getMarkdownASTForFile('TestingPlayground');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-testing-playground-url.com</p>

--- a/src/__tests__/transformers/Twitch.js
+++ b/src/__tests__/transformers/Twitch.js
@@ -8,7 +8,7 @@ import {
   shouldTransform,
 } from '../../transformers/Twitch';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -208,16 +208,13 @@ test('Gets the correct Twitch iframe', () => {
 test('Plugin can transform Twitch links', async () => {
   const markdownAST = getMarkdownASTForFile('Twitch');
 
-  const processedAST = await plugin(
-    { cache, markdownAST },
-    {
-      services: {
-        Twitch: {
-          parent: 'embed.example.com',
-        },
+  const processedAST = await plugin({
+    services: {
+      Twitch: {
+        parent: 'embed.example.com',
       },
-    }
-  );
+    },
+  })(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-twitch-url.tv</p>

--- a/src/__tests__/transformers/Twitter.js
+++ b/src/__tests__/transformers/Twitter.js
@@ -4,7 +4,7 @@ import fetchMock from 'node-fetch';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/Twitter';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
@@ -147,7 +147,7 @@ test('Plugin can transform Twitter links', async () => {
   );
   const markdownAST = getMarkdownASTForFile('Twitter');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-twitter-url.com</p>

--- a/src/__tests__/transformers/YouTube.js
+++ b/src/__tests__/transformers/YouTube.js
@@ -8,7 +8,7 @@ import {
   shouldTransform,
 } from '../../transformers/YouTube';
 
-import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+import { getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -148,7 +148,7 @@ test('Gets the correct YouTube iframe', async () => {
 test('Plugin can transform YouTube links', async () => {
   const markdownAST = getMarkdownASTForFile('YouTube');
 
-  const processedAST = await plugin({ cache, markdownAST });
+  const processedAST = await plugin()(markdownAST);
 
   expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
     <p>https://not-a-youtube-url.com</p>

--- a/src/index.js
+++ b/src/index.js
@@ -19,10 +19,14 @@ const getUrlString = (url) => {
   }
 };
 
-export default async (
-  { cache, markdownAST },
-  { customTransformers = [], services = {} } = {}
-) => {
+const defaultCache = new Map();
+
+async function remarkEmbedderBase({
+  cache = defaultCache,
+  markdownAST,
+  customTransformers = [],
+  services = {},
+}) {
   const transformers = [...defaultTransformers, ...customTransformers];
 
   const transformations = [];
@@ -86,4 +90,18 @@ export default async (
   await Promise.all(transformations.map((t) => t()));
 
   return markdownAST;
-};
+}
+
+function remarkEmbedder(options) {
+  return (tree) => remarkEmbedderBase({ markdownAST: tree, ...options });
+}
+
+function remarkEmbedderGatsby({ cache, markdownAST }, options) {
+  return remarkEmbedderBase({ cache, markdownAST, ...options });
+}
+
+export { remarkEmbedder, remarkEmbedderGatsby };
+
+// TODO: remove this. Will be a breaking change though...
+// would be best to rename the package and remove the default export
+export default remarkEmbedderGatsby;


### PR DESCRIPTION
**What**: feat: export a non-gatsby remark plugin

**Why**: Closes #136

**How**: Slightly refactor the main export to be generic and add two functions for the different APIs offered by remark and gatsby to call into the base function. Export both the remark and gatsby functions. Left the default export as the gatsby one so this could be published without breaking anything.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
