### PR TITLE
tests: check HTML result instead of markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "jest-in-case": "^1.0.2",
     "kcd-scripts": "^6.6.0",
     "pretty-quick": "^3.1.0",
-    "remark": "^12.0.1"
+    "remark": "^12.0.1",
+    "remark-html": "^13.0.1"
   },
   "peerDependencies": {
     "gatsby": "^2.20.0"

--- a/src/__tests__/CustomTransformer.js
+++ b/src/__tests__/CustomTransformer.js
@@ -1,6 +1,6 @@
 import plugin from '../';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from './helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from './helpers';
 
 const transformer = {
   shouldTransform: jest.fn((url) => url.startsWith('https://some-site.com')),
@@ -25,10 +25,9 @@ test('Plugin can transform CustomTransformer links', async () => {
 
   expect(transformer.getHTML).toHaveBeenCalledTimes(1);
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://some-other-site.com/id/abc>
-
-    <iframe src=\\"https://some-site.com/id/abc\\"></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://some-other-site.com/id/abc\\">https://some-other-site.com/id/abc</a></p>
+    <p><iframe src=\\"https://some-site.com/id/abc\\"></iframe></p>
     "
   `);
 });

--- a/src/__tests__/helpers/markdown.js
+++ b/src/__tests__/helpers/markdown.js
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import remark from 'remark';
+import html from 'remark-html';
 
 const getFixturesPath = (isCustomTransformer) =>
   `${__dirname}/../${isCustomTransformer ? '' : 'transformers/'}__fixtures__`;
@@ -13,4 +14,4 @@ const readMarkdownFile = (fileName, isCustomTransformer) =>
 export const getMarkdownASTForFile = (fileName, isCustomTransformer = false) =>
   remark.parse(readMarkdownFile(fileName, isCustomTransformer));
 
-export const parseASTToMarkdown = remark.stringify;
+export const mdastToHtml = (ast) => remark().use(html).stringify(ast);

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -6,7 +6,7 @@ import {
   cache,
   getMarkdownASTForFile,
   mockCache,
-  parseASTToMarkdown,
+  mdastToHtml,
 } from './helpers';
 
 describe('gatsby-remark-embedder', () => {
@@ -37,53 +37,31 @@ describe('gatsby-remark-embedder', () => {
       }
     );
 
-    expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-      "# Heading 1
-
-      ## Heading2
-
-      This is a normal paragraph.
-
-      This is the first line of a multi-line paragraph.  
-      And this is the second line.
-
-      This is a paragraph with a [link](https://example.com).
-
-      [example.com](https://example.com)
-
-      [https://example.com](https://example.com \\"A link to example.com\\")
-
-      <https://example.com>
-
-      [](https://example.com)
-
-      <iframe src=\\"https://codepen.io/team/codepen/embed/preview/PNaGbb\\" style=\\"width:100%; height:300px;\\"></iframe>
-
-      <iframe src=\\"https://codesandbox.io/embed/ynn88nx9x?view=split\\" style=\\"width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;\\" allow=\\"accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking\\" sandbox=\\"allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts\\"></iframe>
-
-      <div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed-from-cache\\" allowfullscreen></iframe></div>
-
-      <blockquote class=\\"instagram-media-from-cache\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote>
-
-      <iframe src=\\"https://lichess.org/embed/MPJcy1JW\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe>
-
-      <a data-pin-do=\\"embedPin\\" href=\\"https://pinterest.com/pin/99360735500167749\\"></a>
-
-      <iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-      <iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe>
-
-      <iframe src=\\"https://open.spotify.com/embed/track/0It2bnTdLl2vyymzOkBI3L\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe>
-
-      <iframe class=\\"streamable-embed-from-cache\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-      <iframe src=\\"https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a?panes=query,preview\\" height=\\"450\\" width=\\"100%\\" scrolling=\\"no\\" frameBorder=\\"0\\" allowTransparency=\\"true\\" style=\\"overflow: hidden; display: block; width: 100%\\"></iframe>
-
-      <iframe src=\\"https://player.twitch.tv?video=546761743&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-      <blockquote class=\\"twitter-tweet-from-cache\\"><p lang=\\"en\\" dir=\\"ltr\\">example</p>&mdash; Kent C. Dodds (@kentcdodds) <a href=\\"https://twitter.com/kentcdodds/status/1078755736455278592\\">December 28, 2018</a></blockquote>
-
-      <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
+    expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+      "<h1>Heading 1</h1>
+      <h2>Heading2</h2>
+      <p>This is a normal paragraph.</p>
+      <p>This is the first line of a multi-line paragraph.<br>
+      And this is the second line.</p>
+      <p>This is a paragraph with a <a href=\\"https://example.com\\">link</a>.</p>
+      <p><a href=\\"https://example.com\\">example.com</a></p>
+      <p><a href=\\"https://example.com\\" title=\\"A link to example.com\\">https://example.com</a></p>
+      <p><a href=\\"https://example.com\\">https://example.com</a></p>
+      <p><a href=\\"https://example.com\\"></a></p>
+      <p><iframe src=\\"https://codepen.io/team/codepen/embed/preview/PNaGbb\\" style=\\"width:100%; height:300px;\\"></iframe></p>
+      <p><iframe src=\\"https://codesandbox.io/embed/ynn88nx9x?view=split\\" style=\\"width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;\\" allow=\\"accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking\\" sandbox=\\"allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts\\"></iframe></p>
+      <p><div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed-from-cache\\" allowfullscreen></iframe></div></p>
+      <p><blockquote class=\\"instagram-media-from-cache\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote></p>
+      <p><iframe src=\\"https://lichess.org/embed/MPJcy1JW\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe></p>
+      <p><a data-pin-do=\\"embedPin\\" href=\\"https://pinterest.com/pin/99360735500167749\\"></a></p>
+      <p><iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+      <p><iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe></p>
+      <p><iframe src=\\"https://open.spotify.com/embed/track/0It2bnTdLl2vyymzOkBI3L\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe></p>
+      <p><iframe class=\\"streamable-embed-from-cache\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+      <p><iframe src=\\"https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a?panes=query,preview\\" height=\\"450\\" width=\\"100%\\" scrolling=\\"no\\" frameBorder=\\"0\\" allowTransparency=\\"true\\" style=\\"overflow: hidden; display: block; width: 100%\\"></iframe></p>
+      <p><iframe src=\\"https://player.twitch.tv?video=546761743&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+      <p><blockquote class=\\"twitter-tweet-from-cache\\"><p lang=\\"en\\" dir=\\"ltr\\">example</p>&mdash; Kent C. Dodds (@kentcdodds) <a href=\\"https://twitter.com/kentcdodds/status/1078755736455278592\\">December 28, 2018</a></blockquote></p>
+      <p><iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe></p>
       "
     `);
   });

--- a/src/__tests__/transformers/CodePen.js
+++ b/src/__tests__/transformers/CodePen.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/CodePen';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -91,38 +91,23 @@ test('Plugin can transform CodePen links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-codepen-url.com>
-
-    <https://this-is-not-codepen.io>
-
-    <https://this-is-not-codepen.io/user/embed/123456>
-
-    <https://this-is-not-codepen.io/user/pen/123456>
-
-    <https://codepen.io/team/codepen>
-
-    <https://codepen.io/MichaelDeBoey>
-
-    <https://codepen.io/random-page>
-
-    <https://blog.codepen.io>
-
-    <https://blog.codepen.io/user/embed/123456>
-
-    <https://blog.codepen.io/user/pen/123456>
-
-    <https://codepen.io/team/codepen/embed/PNaGbb>
-
-    <https://codepen.io/team/codepen/embed/PNaGbb?default-tab=js>
-
-    <iframe src=\\"https://codepen.io/team/codepen/embed/preview/PNaGbb\\" style=\\"width:100%; height:300px;\\"></iframe>
-
-    <iframe src=\\"https://www.codepen.io/team/codepen/embed/preview/PNaGbb\\" style=\\"width:100%; height:300px;\\"></iframe>
-
-    <iframe src=\\"https://codepen.io/chriscoyier/embed/preview/owBwKM\\" style=\\"width:100%; height:300px;\\"></iframe>
-
-    <iframe src=\\"https://www.codepen.io/chriscoyier/embed/preview/owBwKM\\" style=\\"width:100%; height:300px;\\"></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-codepen-url.com\\">https://not-a-codepen-url.com</a></p>
+    <p><a href=\\"https://this-is-not-codepen.io\\">https://this-is-not-codepen.io</a></p>
+    <p><a href=\\"https://this-is-not-codepen.io/user/embed/123456\\">https://this-is-not-codepen.io/user/embed/123456</a></p>
+    <p><a href=\\"https://this-is-not-codepen.io/user/pen/123456\\">https://this-is-not-codepen.io/user/pen/123456</a></p>
+    <p><a href=\\"https://codepen.io/team/codepen\\">https://codepen.io/team/codepen</a></p>
+    <p><a href=\\"https://codepen.io/MichaelDeBoey\\">https://codepen.io/MichaelDeBoey</a></p>
+    <p><a href=\\"https://codepen.io/random-page\\">https://codepen.io/random-page</a></p>
+    <p><a href=\\"https://blog.codepen.io\\">https://blog.codepen.io</a></p>
+    <p><a href=\\"https://blog.codepen.io/user/embed/123456\\">https://blog.codepen.io/user/embed/123456</a></p>
+    <p><a href=\\"https://blog.codepen.io/user/pen/123456\\">https://blog.codepen.io/user/pen/123456</a></p>
+    <p><a href=\\"https://codepen.io/team/codepen/embed/PNaGbb\\">https://codepen.io/team/codepen/embed/PNaGbb</a></p>
+    <p><a href=\\"https://codepen.io/team/codepen/embed/PNaGbb?default-tab=js\\">https://codepen.io/team/codepen/embed/PNaGbb?default-tab=js</a></p>
+    <p><iframe src=\\"https://codepen.io/team/codepen/embed/preview/PNaGbb\\" style=\\"width:100%; height:300px;\\"></iframe></p>
+    <p><iframe src=\\"https://www.codepen.io/team/codepen/embed/preview/PNaGbb\\" style=\\"width:100%; height:300px;\\"></iframe></p>
+    <p><iframe src=\\"https://codepen.io/chriscoyier/embed/preview/owBwKM\\" style=\\"width:100%; height:300px;\\"></iframe></p>
+    <p><iframe src=\\"https://www.codepen.io/chriscoyier/embed/preview/owBwKM\\" style=\\"width:100%; height:300px;\\"></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/CodeSandbox.js
+++ b/src/__tests__/transformers/CodeSandbox.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/CodeSandbox';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -55,20 +55,14 @@ test('Plugin can transform CodeSandbox links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-codesandbox-url.com>
-
-    <https://this-is-not-codesandbox.io>
-
-    <https://this-is-not-codesandbox.io/s/ynn88nx9x>
-
-    <https://codesandbox.io/embed/ynn88nx9x>
-
-    <iframe src=\\"https://codesandbox.io/embed/ynn88nx9x\\" style=\\"width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;\\" allow=\\"accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking\\" sandbox=\\"allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts\\"></iframe>
-
-    <iframe src=\\"https://codesandbox.io/embed/ynn88nx9x?view=split\\" style=\\"width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;\\" allow=\\"accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking\\" sandbox=\\"allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts\\"></iframe>
-
-    <iframe src=\\"https://www.codesandbox.io/embed/ynn88nx9x\\" style=\\"width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;\\" allow=\\"accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking\\" sandbox=\\"allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts\\"></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-codesandbox-url.com\\">https://not-a-codesandbox-url.com</a></p>
+    <p><a href=\\"https://this-is-not-codesandbox.io\\">https://this-is-not-codesandbox.io</a></p>
+    <p><a href=\\"https://this-is-not-codesandbox.io/s/ynn88nx9x\\">https://this-is-not-codesandbox.io/s/ynn88nx9x</a></p>
+    <p><a href=\\"https://codesandbox.io/embed/ynn88nx9x\\">https://codesandbox.io/embed/ynn88nx9x</a></p>
+    <p><iframe src=\\"https://codesandbox.io/embed/ynn88nx9x\\" style=\\"width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;\\" allow=\\"accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking\\" sandbox=\\"allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts\\"></iframe></p>
+    <p><iframe src=\\"https://codesandbox.io/embed/ynn88nx9x?view=split\\" style=\\"width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;\\" allow=\\"accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking\\" sandbox=\\"allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts\\"></iframe></p>
+    <p><iframe src=\\"https://www.codesandbox.io/embed/ynn88nx9x\\" style=\\"width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;\\" allow=\\"accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking\\" sandbox=\\"allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts\\"></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/GIPHY.js
+++ b/src/__tests__/transformers/GIPHY.js
@@ -9,7 +9,7 @@ import {
   shouldTransform,
 } from '../../transformers/GIPHY';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
@@ -143,26 +143,17 @@ test('Plugin can transform GIPHY links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-giphy-url.com>
-
-    <https://this-is-not-giphy.com>
-
-    <https://this-is-not-giphy.com/gifs/howtogiphygifs-how-to-XatG8bioEwwVO>
-
-    <https://giphy.com>
-
-    <https://giphy.com/videos/blesstheharts-wayne-bless-the-harts-ciwJyqlgAYkvguS2Nw>
-
-    <div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div>
-
-    <div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div>
-
-    <div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div>
-
-    <div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div>
-
-    <div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-giphy-url.com\\">https://not-a-giphy-url.com</a></p>
+    <p><a href=\\"https://this-is-not-giphy.com\\">https://this-is-not-giphy.com</a></p>
+    <p><a href=\\"https://this-is-not-giphy.com/gifs/howtogiphygifs-how-to-XatG8bioEwwVO\\">https://this-is-not-giphy.com/gifs/howtogiphygifs-how-to-XatG8bioEwwVO</a></p>
+    <p><a href=\\"https://giphy.com\\">https://giphy.com</a></p>
+    <p><a href=\\"https://giphy.com/videos/blesstheharts-wayne-bless-the-harts-ciwJyqlgAYkvguS2Nw\\">https://giphy.com/videos/blesstheharts-wayne-bless-the-harts-ciwJyqlgAYkvguS2Nw</a></p>
+    <p><div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div></p>
+    <p><div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div></p>
+    <p><div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div></p>
+    <p><div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div></p>
+    <p><div style=\\"width:100%;height:0;padding-bottom:63%;position:relative;\\"><iframe src=\\"https://giphy.com/embed/XatG8bioEwwVO\\" width=\\"100%\\" height=\\"100%\\" style=\\"position:absolute\\" frameborder=\\"0\\" class=\\"giphy-embed\\" allowfullscreen></iframe></div></p>
     "
   `);
 });

--- a/src/__tests__/transformers/Instagram.js
+++ b/src/__tests__/transformers/Instagram.js
@@ -4,7 +4,7 @@ import fetchMock from 'node-fetch';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/Instagram';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
@@ -130,42 +130,25 @@ test('Plugin can transform Instagram links', async () => {
     }
   );
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-an-instagram-url.com>
-
-    <https://this-is-not-instagr.am>
-
-    <https://this-is-not-instagram.com>
-
-    <https://this-is-not-instagr.am/p/B60jPE6J8U->
-
-    <https://this-is-not-instagram.com/p/B60jPE6J8U->
-
-    <https://instagram.com>
-
-    <https://instagram.com/accounts/activity>
-
-    <https://instagram.com/accounts/edit>
-
-    <https://instagram.com/accounts/password/change>
-
-    <https://instagram.com/explore>
-
-    <https://instagram.com/nametag>
-
-    <https://instagram.com/MichaelDeBoey>
-
-    <https://about.instagram.com>
-
-    <https://help.instagram.com>
-
-    <blockquote class=\\"instagram-media-mocked-fetch-plugin\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote>
-
-    <blockquote class=\\"instagram-media-mocked-fetch-plugin\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote>
-
-    <blockquote class=\\"instagram-media-mocked-fetch-plugin\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote>
-
-    <blockquote class=\\"instagram-media-mocked-fetch-plugin\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-an-instagram-url.com\\">https://not-an-instagram-url.com</a></p>
+    <p><a href=\\"https://this-is-not-instagr.am\\">https://this-is-not-instagr.am</a></p>
+    <p><a href=\\"https://this-is-not-instagram.com\\">https://this-is-not-instagram.com</a></p>
+    <p><a href=\\"https://this-is-not-instagr.am/p/B60jPE6J8U-\\">https://this-is-not-instagr.am/p/B60jPE6J8U-</a></p>
+    <p><a href=\\"https://this-is-not-instagram.com/p/B60jPE6J8U-\\">https://this-is-not-instagram.com/p/B60jPE6J8U-</a></p>
+    <p><a href=\\"https://instagram.com\\">https://instagram.com</a></p>
+    <p><a href=\\"https://instagram.com/accounts/activity\\">https://instagram.com/accounts/activity</a></p>
+    <p><a href=\\"https://instagram.com/accounts/edit\\">https://instagram.com/accounts/edit</a></p>
+    <p><a href=\\"https://instagram.com/accounts/password/change\\">https://instagram.com/accounts/password/change</a></p>
+    <p><a href=\\"https://instagram.com/explore\\">https://instagram.com/explore</a></p>
+    <p><a href=\\"https://instagram.com/nametag\\">https://instagram.com/nametag</a></p>
+    <p><a href=\\"https://instagram.com/MichaelDeBoey\\">https://instagram.com/MichaelDeBoey</a></p>
+    <p><a href=\\"https://about.instagram.com\\">https://about.instagram.com</a></p>
+    <p><a href=\\"https://help.instagram.com\\">https://help.instagram.com</a></p>
+    <p><blockquote class=\\"instagram-media-mocked-fetch-plugin\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote></p>
+    <p><blockquote class=\\"instagram-media-mocked-fetch-plugin\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote></p>
+    <p><blockquote class=\\"instagram-media-mocked-fetch-plugin\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote></p>
+    <p><blockquote class=\\"instagram-media-mocked-fetch-plugin\\"><div><a href=\\"https://instagram.com/p/B60jPE6J8U-\\"><p>example</p></a><p>A post shared by <a href=\\"https://instagram.com/michaeldeboey\\">Michaël De Boey</a> (@michaeldeboey) on<timedatetime=\\"2020-01-02T14:45:30+00:00\\">Jan 2, 2020 at 6:45am PST</time></p></div></blockquote></p>
     "
   `);
 });

--- a/src/__tests__/transformers/Lichess.js
+++ b/src/__tests__/transformers/Lichess.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/Lichess';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -95,40 +95,24 @@ test('Plugin can transform Lichess links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-lichess-url.org>
-
-    <https://this-is-not-lichess.org>
-
-    <https://this-is-not-lichess.org/embed/MPJcy1JW>
-
-    <https://lichess.org/embed/MPJcy1JW>
-
-    <https://lichess.org/learn>
-
-    <https://lichess.org/practice>
-
-    <https://lichess.org/study>
-
-    <https://lichess.org/study/XtFCFYlM>
-
-    <https://lichess.org/training/12345>
-
-    <https://lichess.org/tv>
-
-    <https://lichess.org/tv/best>
-
-    <iframe src=\\"https://lichess.org/embed/MPJcy1JW\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe>
-
-    <iframe src=\\"https://www.lichess.org/embed/MPJcy1JW\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe>
-
-    <iframe src=\\"https://lichess.org/embed/MPJcy1JW?theme=auto&bg=auto\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe>
-
-    <iframe src=\\"https://www.lichess.org/embed/MPJcy1JW?theme=auto&bg=auto\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe>
-
-    <iframe src=\\"https://lichess.org/embed/tv123abc56de\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe>
-
-    <iframe src=\\"https://www.lichess.org/embed/tv123abc56de\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-lichess-url.org\\">https://not-a-lichess-url.org</a></p>
+    <p><a href=\\"https://this-is-not-lichess.org\\">https://this-is-not-lichess.org</a></p>
+    <p><a href=\\"https://this-is-not-lichess.org/embed/MPJcy1JW\\">https://this-is-not-lichess.org/embed/MPJcy1JW</a></p>
+    <p><a href=\\"https://lichess.org/embed/MPJcy1JW\\">https://lichess.org/embed/MPJcy1JW</a></p>
+    <p><a href=\\"https://lichess.org/learn\\">https://lichess.org/learn</a></p>
+    <p><a href=\\"https://lichess.org/practice\\">https://lichess.org/practice</a></p>
+    <p><a href=\\"https://lichess.org/study\\">https://lichess.org/study</a></p>
+    <p><a href=\\"https://lichess.org/study/XtFCFYlM\\">https://lichess.org/study/XtFCFYlM</a></p>
+    <p><a href=\\"https://lichess.org/training/12345\\">https://lichess.org/training/12345</a></p>
+    <p><a href=\\"https://lichess.org/tv\\">https://lichess.org/tv</a></p>
+    <p><a href=\\"https://lichess.org/tv/best\\">https://lichess.org/tv/best</a></p>
+    <p><iframe src=\\"https://lichess.org/embed/MPJcy1JW\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe></p>
+    <p><iframe src=\\"https://www.lichess.org/embed/MPJcy1JW\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe></p>
+    <p><iframe src=\\"https://lichess.org/embed/MPJcy1JW?theme=auto&bg=auto\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe></p>
+    <p><iframe src=\\"https://www.lichess.org/embed/MPJcy1JW?theme=auto&bg=auto\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe></p>
+    <p><iframe src=\\"https://lichess.org/embed/tv123abc56de\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe></p>
+    <p><iframe src=\\"https://www.lichess.org/embed/tv123abc56de\\" width=\\"600\\" height=\\"397\\" frameborder=\\"0\\"></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/Pinterest.js
+++ b/src/__tests__/transformers/Pinterest.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../..';
 import { getHTML, shouldTransform } from '../../transformers/Pinterest';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -79,24 +79,16 @@ test('Plugin can transform Pinterest links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-pinterest-url.com>
-
-    <https://this-is-not-pinterest.com>
-
-    <https://this-is-not-pinterest.com/pin/99360735500167749>
-
-    <a data-pin-do=\\"embedBoard\\" data-pin-board-width=\\"400\\" data-pin-scale-height=\\"240\\" data-pin-scale-width=\\"80\\" href=\\"https://pinterest.com/pinterest/official-news\\"></a>
-
-    <a data-pin-do=\\"embedBoard\\" data-pin-board-width=\\"400\\" data-pin-scale-height=\\"240\\" data-pin-scale-width=\\"80\\" href=\\"https://www.pinterest.com/pinterest/official-news\\"></a>
-
-    <a data-pin-do=\\"embedPin\\" href=\\"https://pinterest.com/pin/99360735500167749\\"></a>
-
-    <a data-pin-do=\\"embedPin\\" href=\\"https://www.pinterest.com/pin/99360735500167749\\"></a>
-
-    <a data-pin-do=\\"embedUser\\" data-pin-board-width=\\"400\\" data-pin-scale-height=\\"240\\" data-pin-scale-width=\\"80\\" href=\\"https://pinterest.com/pinterest\\"></a>
-
-    <a data-pin-do=\\"embedUser\\" data-pin-board-width=\\"400\\" data-pin-scale-height=\\"240\\" data-pin-scale-width=\\"80\\" href=\\"https://www.pinterest.com/pinterest\\"></a>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-pinterest-url.com\\">https://not-a-pinterest-url.com</a></p>
+    <p><a href=\\"https://this-is-not-pinterest.com\\">https://this-is-not-pinterest.com</a></p>
+    <p><a href=\\"https://this-is-not-pinterest.com/pin/99360735500167749\\">https://this-is-not-pinterest.com/pin/99360735500167749</a></p>
+    <p><a data-pin-do=\\"embedBoard\\" data-pin-board-width=\\"400\\" data-pin-scale-height=\\"240\\" data-pin-scale-width=\\"80\\" href=\\"https://pinterest.com/pinterest/official-news\\"></a></p>
+    <p><a data-pin-do=\\"embedBoard\\" data-pin-board-width=\\"400\\" data-pin-scale-height=\\"240\\" data-pin-scale-width=\\"80\\" href=\\"https://www.pinterest.com/pinterest/official-news\\"></a></p>
+    <p><a data-pin-do=\\"embedPin\\" href=\\"https://pinterest.com/pin/99360735500167749\\"></a></p>
+    <p><a data-pin-do=\\"embedPin\\" href=\\"https://www.pinterest.com/pin/99360735500167749\\"></a></p>
+    <p><a data-pin-do=\\"embedUser\\" data-pin-board-width=\\"400\\" data-pin-scale-height=\\"240\\" data-pin-scale-width=\\"80\\" href=\\"https://pinterest.com/pinterest\\"></a></p>
+    <p><a data-pin-do=\\"embedUser\\" data-pin-board-width=\\"400\\" data-pin-scale-height=\\"240\\" data-pin-scale-width=\\"80\\" href=\\"https://www.pinterest.com/pinterest\\"></a></p>
     "
   `);
 });

--- a/src/__tests__/transformers/Slides.js
+++ b/src/__tests__/transformers/Slides.js
@@ -7,7 +7,7 @@ import {
   shouldTransform,
 } from '../../transformers/Slides';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -220,70 +220,39 @@ test('Plugin can transform Slides links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-slides-url.com>
-
-    <https://this-is-not-slides.com>
-
-    <https://this-is-not-slides.com/kentcdodds/oss-we-want>
-
-    <https://slides.com>
-
-    <https://slides.com/explore>
-
-    <https://slides.com/random-page>
-
-    <https://team.slides.com/hakimel/finch/embed>
-
-    <https://team.slides.com/hakimel/finch/fullscreen>
-
-    <https://team.slides.com/hakimel/finch/live>
-
-    <https://dotted.team.slides.com/username/deck-name>
-
-    <https://a.slides.com/username/deck-name>
-
-    <https://slides.com/kentcdodds/oss-we-want/embed>
-
-    <https://slides.com/kentcdodds/oss-we-want/fullscreen>
-
-    <https://slides.com/kentcdodds/oss-we-want/live>
-
-    <iframe src=\\"https://team.slides.com/hakimel/finch/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://acme.slides.com/jack-k/sales-template/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://team-name.slides.com/username/deck-name/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://team_name.slides.com/username/deck-name/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://asdfdsa11232889asd.slides.com/username/deck-name/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://ab.slides.com/username/deck-name/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://team.slides.com/hakimel/finch/embed#/0\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://team.slides.com/hakimel/finch/embed#/0\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://team.slides.com/username/embed/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://team.slides.com/username/fullscreen/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://team.slides.com/username/live/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://slides.com/michaeldeboey/embed/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://slides.com/michaeldeboey/fullscreen/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://slides.com/michaeldeboey/live/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed#/0\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-
-    <iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed#/0\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-slides-url.com\\">https://not-a-slides-url.com</a></p>
+    <p><a href=\\"https://this-is-not-slides.com\\">https://this-is-not-slides.com</a></p>
+    <p><a href=\\"https://this-is-not-slides.com/kentcdodds/oss-we-want\\">https://this-is-not-slides.com/kentcdodds/oss-we-want</a></p>
+    <p><a href=\\"https://slides.com\\">https://slides.com</a></p>
+    <p><a href=\\"https://slides.com/explore\\">https://slides.com/explore</a></p>
+    <p><a href=\\"https://slides.com/random-page\\">https://slides.com/random-page</a></p>
+    <p><a href=\\"https://team.slides.com/hakimel/finch/embed\\">https://team.slides.com/hakimel/finch/embed</a></p>
+    <p><a href=\\"https://team.slides.com/hakimel/finch/fullscreen\\">https://team.slides.com/hakimel/finch/fullscreen</a></p>
+    <p><a href=\\"https://team.slides.com/hakimel/finch/live\\">https://team.slides.com/hakimel/finch/live</a></p>
+    <p><a href=\\"https://dotted.team.slides.com/username/deck-name\\">https://dotted.team.slides.com/username/deck-name</a></p>
+    <p><a href=\\"https://a.slides.com/username/deck-name\\">https://a.slides.com/username/deck-name</a></p>
+    <p><a href=\\"https://slides.com/kentcdodds/oss-we-want/embed\\">https://slides.com/kentcdodds/oss-we-want/embed</a></p>
+    <p><a href=\\"https://slides.com/kentcdodds/oss-we-want/fullscreen\\">https://slides.com/kentcdodds/oss-we-want/fullscreen</a></p>
+    <p><a href=\\"https://slides.com/kentcdodds/oss-we-want/live\\">https://slides.com/kentcdodds/oss-we-want/live</a></p>
+    <p><iframe src=\\"https://team.slides.com/hakimel/finch/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://acme.slides.com/jack-k/sales-template/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://team-name.slides.com/username/deck-name/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://team_name.slides.com/username/deck-name/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://asdfdsa11232889asd.slides.com/username/deck-name/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://ab.slides.com/username/deck-name/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://team.slides.com/hakimel/finch/embed#/0\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://team.slides.com/hakimel/finch/embed#/0\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://team.slides.com/username/embed/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://team.slides.com/username/fullscreen/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://team.slides.com/username/live/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://slides.com/michaeldeboey/embed/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://slides.com/michaeldeboey/fullscreen/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://slides.com/michaeldeboey/live/embed\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed#/0\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://slides.com/kentcdodds/oss-we-want/embed#/0\\" width=\\"576\\" height=\\"420\\" scrolling=\\"no\\" frameborder=\\"0\\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/SoundCloud.js
+++ b/src/__tests__/transformers/SoundCloud.js
@@ -3,7 +3,7 @@ import cases from 'jest-in-case';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/SoundCloud';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -56,20 +56,14 @@ test('Plugin can transform SoundCloud links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-soundcloud-url.com>
-
-    <https://this-is-not-soundcloud.com>
-
-    <https://api.soundcloud.com/tracks/151129490>
-
-    <https://api.soundcloud.com/playlists/703823211>
-
-    <https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa>
-
-    <iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe>
-
-    <iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" src=https://w.soundcloud.com/player?url=http://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-soundcloud-url.com\\">https://not-a-soundcloud-url.com</a></p>
+    <p><a href=\\"https://this-is-not-soundcloud.com\\">https://this-is-not-soundcloud.com</a></p>
+    <p><a href=\\"https://api.soundcloud.com/tracks/151129490\\">https://api.soundcloud.com/tracks/151129490</a></p>
+    <p><a href=\\"https://api.soundcloud.com/playlists/703823211\\">https://api.soundcloud.com/playlists/703823211</a></p>
+    <p><a href=\\"https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa\\">https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa</a></p>
+    <p><iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" src=https://w.soundcloud.com/player?url=https://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe></p>
+    <p><iframe width=\\"100%\\" height=\\"300\\" scrolling=\\"no\\" frameborder=\\"no\\" src=https://w.soundcloud.com/player?url=http://soundcloud.com/clemenswenners/africa&color=ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=false&visual=true></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/Spotify.js
+++ b/src/__tests__/transformers/Spotify.js
@@ -7,7 +7,7 @@ import {
   shouldTransform,
 } from '../../transformers/Spotify';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -127,36 +127,22 @@ test('Plugin can transform Spotify links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-spotify-url.com>
-
-    <https://this-is-not-spotify.com>
-
-    <https://api.spotify.com/album/1DFixLWuPkv3KT3TnV35m3>
-
-    <https://open.spotify.com/embed/album/254Y0CD07dB40q84db89EB>
-
-    <https://open.spotify.com/embed/artist/0QaSiI5TLA4N7mcsdxShDO>
-
-    <https://open.spotify.com/embed-podcast/episode/0j9RE1H47GSmBnRqOtf1dx>
-
-    <https://open.spotify.com/embed/playlist/37i9dQZF1DX5wDmLW735Yd>
-
-    <https://open.spotify.com/embed-podcast/show/7GkO2poedjbltWT5lduL5w>
-
-    <https://open.spotify.com/embed/track/0It2bnTdLl2vyymzOkBI3L>
-
-    <iframe src=\\"https://open.spotify.com/embed/album/254Y0CD07dB40q84db89EB\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe>
-
-    <iframe src=\\"https://open.spotify.com/embed/artist/0QaSiI5TLA4N7mcsdxShDO\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe>
-
-    <iframe src=\\"https://open.spotify.com/embed-podcast/episode/0j9RE1H47GSmBnRqOtf1dx\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe>
-
-    <iframe src=\\"https://open.spotify.com/embed/playlist/37i9dQZF1DX5wDmLW735Yd\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe>
-
-    <iframe src=\\"https://open.spotify.com/embed-podcast/show/7GkO2poedjbltWT5lduL5w\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe>
-
-    <iframe src=\\"https://open.spotify.com/embed/track/0It2bnTdLl2vyymzOkBI3L\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-spotify-url.com\\">https://not-a-spotify-url.com</a></p>
+    <p><a href=\\"https://this-is-not-spotify.com\\">https://this-is-not-spotify.com</a></p>
+    <p><a href=\\"https://api.spotify.com/album/1DFixLWuPkv3KT3TnV35m3\\">https://api.spotify.com/album/1DFixLWuPkv3KT3TnV35m3</a></p>
+    <p><a href=\\"https://open.spotify.com/embed/album/254Y0CD07dB40q84db89EB\\">https://open.spotify.com/embed/album/254Y0CD07dB40q84db89EB</a></p>
+    <p><a href=\\"https://open.spotify.com/embed/artist/0QaSiI5TLA4N7mcsdxShDO\\">https://open.spotify.com/embed/artist/0QaSiI5TLA4N7mcsdxShDO</a></p>
+    <p><a href=\\"https://open.spotify.com/embed-podcast/episode/0j9RE1H47GSmBnRqOtf1dx\\">https://open.spotify.com/embed-podcast/episode/0j9RE1H47GSmBnRqOtf1dx</a></p>
+    <p><a href=\\"https://open.spotify.com/embed/playlist/37i9dQZF1DX5wDmLW735Yd\\">https://open.spotify.com/embed/playlist/37i9dQZF1DX5wDmLW735Yd</a></p>
+    <p><a href=\\"https://open.spotify.com/embed-podcast/show/7GkO2poedjbltWT5lduL5w\\">https://open.spotify.com/embed-podcast/show/7GkO2poedjbltWT5lduL5w</a></p>
+    <p><a href=\\"https://open.spotify.com/embed/track/0It2bnTdLl2vyymzOkBI3L\\">https://open.spotify.com/embed/track/0It2bnTdLl2vyymzOkBI3L</a></p>
+    <p><iframe src=\\"https://open.spotify.com/embed/album/254Y0CD07dB40q84db89EB\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe></p>
+    <p><iframe src=\\"https://open.spotify.com/embed/artist/0QaSiI5TLA4N7mcsdxShDO\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe></p>
+    <p><iframe src=\\"https://open.spotify.com/embed-podcast/episode/0j9RE1H47GSmBnRqOtf1dx\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe></p>
+    <p><iframe src=\\"https://open.spotify.com/embed/playlist/37i9dQZF1DX5wDmLW735Yd\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe></p>
+    <p><iframe src=\\"https://open.spotify.com/embed-podcast/show/7GkO2poedjbltWT5lduL5w\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe></p>
+    <p><iframe src=\\"https://open.spotify.com/embed/track/0It2bnTdLl2vyymzOkBI3L\\" width=\\"100%\\" height=\\"380\\" frameborder=\\"0\\" allowtransparency=\\"true\\" allow=\\"encrypted-media\\"></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/Streamable.js
+++ b/src/__tests__/transformers/Streamable.js
@@ -8,7 +8,7 @@ import {
   shouldTransform,
 } from '../../transformers/Streamable';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
@@ -195,52 +195,30 @@ test('Plugin correctly transforms Streamable links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-streamable-url.com>
-
-    <https://this-is-not-streamable.com>
-
-    <https://streamable.com/documentation>
-
-    <https://streamable.com/login>
-
-    <https://streamable.com/recover>
-
-    <https://streamable.com/settings>
-
-    <https://streamable.com/signup>
-
-    <https://streamable.com/e/moo/username/extra>
-
-    <https://streamable.com/g/moo/username/extra>
-
-    <https://streamable.com/o/moo/username/extra>
-
-    <https://streamable.com/s/moo/username/extra>
-
-    <https://streamable.com/t/moo/username/extra>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
-
-    <iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-streamable-url.com\\">https://not-a-streamable-url.com</a></p>
+    <p><a href=\\"https://this-is-not-streamable.com\\">https://this-is-not-streamable.com</a></p>
+    <p><a href=\\"https://streamable.com/documentation\\">https://streamable.com/documentation</a></p>
+    <p><a href=\\"https://streamable.com/login\\">https://streamable.com/login</a></p>
+    <p><a href=\\"https://streamable.com/recover\\">https://streamable.com/recover</a></p>
+    <p><a href=\\"https://streamable.com/settings\\">https://streamable.com/settings</a></p>
+    <p><a href=\\"https://streamable.com/signup\\">https://streamable.com/signup</a></p>
+    <p><a href=\\"https://streamable.com/e/moo/username/extra\\">https://streamable.com/e/moo/username/extra</a></p>
+    <p><a href=\\"https://streamable.com/g/moo/username/extra\\">https://streamable.com/g/moo/username/extra</a></p>
+    <p><a href=\\"https://streamable.com/o/moo/username/extra\\">https://streamable.com/o/moo/username/extra</a></p>
+    <p><a href=\\"https://streamable.com/s/moo/username/extra\\">https://streamable.com/s/moo/username/extra</a></p>
+    <p><a href=\\"https://streamable.com/t/moo/username/extra\\">https://streamable.com/t/moo/username/extra</a></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
+    <p><iframe class=\\"streamable-embed-mocked-fetch-plugin\\" src=\\"https://streamable.com/o/moo\\" frameborder=\\"0\\" scrolling=\\"no\\" width=\\"1920\\" height=\\"1080\\" allowfullscreen></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/TestingPlayground.js
+++ b/src/__tests__/transformers/TestingPlayground.js
@@ -7,7 +7,7 @@ import {
   shouldTransform,
 } from '../../transformers/TestingPlayground';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -97,24 +97,16 @@ test('Plugin can transform Testing Playground links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-testing-playground-url.com>
-
-    <https://this-is-not-testing-playground.com>
-
-    <https://this-is-not-testing-playground.com/gist/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a>
-
-    <https://this-is-not-testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a>
-
-    <https://testing-playground.com/.well-known/dnt-policy.txt>
-
-    <https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a>
-
-    <iframe src=\\"https://testing-playground.com/embed?panes=query,preview\\" height=\\"450\\" width=\\"100%\\" scrolling=\\"no\\" frameBorder=\\"0\\" allowTransparency=\\"true\\" style=\\"overflow: hidden; display: block; width: 100%\\"></iframe>
-
-    <iframe src=\\"https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a?panes=query,preview\\" height=\\"450\\" width=\\"100%\\" scrolling=\\"no\\" frameBorder=\\"0\\" allowTransparency=\\"true\\" style=\\"overflow: hidden; display: block; width: 100%\\"></iframe>
-
-    <iframe src=\\"https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a?panes=query,preview\\" height=\\"450\\" width=\\"100%\\" scrolling=\\"no\\" frameBorder=\\"0\\" allowTransparency=\\"true\\" style=\\"overflow: hidden; display: block; width: 100%\\"></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-testing-playground-url.com\\">https://not-a-testing-playground-url.com</a></p>
+    <p><a href=\\"https://this-is-not-testing-playground.com\\">https://this-is-not-testing-playground.com</a></p>
+    <p><a href=\\"https://this-is-not-testing-playground.com/gist/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a\\">https://this-is-not-testing-playground.com/gist/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a</a></p>
+    <p><a href=\\"https://this-is-not-testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a\\">https://this-is-not-testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a</a></p>
+    <p><a href=\\"https://testing-playground.com/.well-known/dnt-policy.txt\\">https://testing-playground.com/.well-known/dnt-policy.txt</a></p>
+    <p><a href=\\"https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a\\">https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a</a></p>
+    <p><iframe src=\\"https://testing-playground.com/embed?panes=query,preview\\" height=\\"450\\" width=\\"100%\\" scrolling=\\"no\\" frameBorder=\\"0\\" allowTransparency=\\"true\\" style=\\"overflow: hidden; display: block; width: 100%\\"></iframe></p>
+    <p><iframe src=\\"https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a?panes=query,preview\\" height=\\"450\\" width=\\"100%\\" scrolling=\\"no\\" frameBorder=\\"0\\" allowTransparency=\\"true\\" style=\\"overflow: hidden; display: block; width: 100%\\"></iframe></p>
+    <p><iframe src=\\"https://testing-playground.com/embed/fb336c386145b235372a0f57d5c58205/6d13e4ee508301c8b42f9d2cc8584e70bb05fb4a?panes=query,preview\\" height=\\"450\\" width=\\"100%\\" scrolling=\\"no\\" frameBorder=\\"0\\" allowTransparency=\\"true\\" style=\\"overflow: hidden; display: block; width: 100%\\"></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/Twitch.js
+++ b/src/__tests__/transformers/Twitch.js
@@ -8,7 +8,7 @@ import {
   shouldTransform,
 } from '../../transformers/Twitch';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -219,50 +219,29 @@ test('Plugin can transform Twitch links', async () => {
     }
   );
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-twitch-url.tv>
-
-    <https://this-is-not-twitch.tv>
-
-    <https://blog.twitch.tv>
-
-    <https://twitch.tv/jlengstorf/followers>
-
-    <https://twitch.tv>
-
-    <https://twitch.tv/settings/profile>
-
-    <https://twitch.tv/jlengstorf/videos>
-
-    <https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame>
-
-    <iframe src=\\"https://player.twitch.tv?channel=jlengstorf&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?channel=jlengstorf&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?channel=jlengstorf&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?video=546761743&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?video=546761743&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
-
-    <iframe src=\\"https://player.twitch.tv?video=546761743&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-twitch-url.tv\\">https://not-a-twitch-url.tv</a></p>
+    <p><a href=\\"https://this-is-not-twitch.tv\\">https://this-is-not-twitch.tv</a></p>
+    <p><a href=\\"https://blog.twitch.tv\\">https://blog.twitch.tv</a></p>
+    <p><a href=\\"https://twitch.tv/jlengstorf/followers\\">https://twitch.tv/jlengstorf/followers</a></p>
+    <p><a href=\\"https://twitch.tv\\">https://twitch.tv</a></p>
+    <p><a href=\\"https://twitch.tv/settings/profile\\">https://twitch.tv/settings/profile</a></p>
+    <p><a href=\\"https://twitch.tv/jlengstorf/videos\\">https://twitch.tv/jlengstorf/videos</a></p>
+    <p><a href=\\"https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame\\">https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame</a></p>
+    <p><iframe src=\\"https://player.twitch.tv?channel=jlengstorf&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?channel=jlengstorf&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?channel=jlengstorf&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://clips.twitch.tv/embed?clip=PeacefulAbstrusePorcupineDansGame&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?collection=DHetedhyqBSVMg&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?video=546761743&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?video=546761743&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
+    <p><iframe src=\\"https://player.twitch.tv?video=546761743&parent=embed.example.com\\" height=\\"300\\" width=\\"100%\\" frameborder=\\"0\\" scrolling=\\"no\\" allowfullscreen></iframe></p>
     "
   `);
 });

--- a/src/__tests__/transformers/Twitter.js
+++ b/src/__tests__/transformers/Twitter.js
@@ -4,7 +4,7 @@ import fetchMock from 'node-fetch';
 import plugin from '../../';
 import { getHTML, shouldTransform } from '../../transformers/Twitter';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
@@ -149,38 +149,23 @@ test('Plugin can transform Twitter links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-twitter-url.com>
-
-    <https://this-is-not-twitter.com>
-
-    <https://this-is-not-twitter.com/i/events/123>
-
-    <https://this-is-not-twitter.com/i/moments/123>
-
-    <https://this-is-not-twitter.com/foobar/status/123>
-
-    <https://this-is-not-twitter.com/foobar/timelines/123>
-
-    <https://twitter.com/MichaelDeBoey93>
-
-    <https://twitter.com/i/moments/edit/994601867987619840>
-
-    <blockquote class=\\"twitter-tweet-mocked-fetch-plugin\\"><p lang=\\"en\\" dir=\\"ltr\\">example</p>&mdash; Kent C. Dodds (@kentcdodds) <a href=\\"https://twitter.com/kentcdodds/status/1078755736455278592\\">December 28, 2018</a></blockquote>
-
-    <blockquote class=\\"twitter-tweet-mocked-fetch-plugin\\"><p lang=\\"en\\" dir=\\"ltr\\">example</p>&mdash; Kent C. Dodds (@kentcdodds) <a href=\\"https://twitter.com/kentcdodds/status/1078755736455278592\\">December 28, 2018</a></blockquote>
-
-    <a class=\\"twitter-moment-mocked-fetch-plugin\\" href=\\"https://twitter.com/i/moments/994601867987619840\\">🔥 Design Tips</a>
-
-    <a class=\\"twitter-moment-mocked-fetch-plugin\\" href=\\"https://twitter.com/i/moments/994601867987619840\\">🔥 Design Tips</a>
-
-    <a class=\\"twitter-moment-mocked-fetch-plugin\\" href=\\"https://twitter.com/i/moments/994601867987619840\\">🔥 Design Tips</a>
-
-    <a class=\\"twitter-moment-mocked-fetch-plugin\\" href=\\"https://twitter.com/i/moments/994601867987619840\\">🔥 Design Tips</a>
-
-    <a class=\\"twitter-timeline-mocked-fetch-plugin\\" href=\\"https://twitter.com/wesbos/timelines/1189618481672667136\\">🔥 Hot Tips from Wes Bos - Curated tweets by wesbos</a>
-
-    <a class=\\"twitter-timeline-mocked-fetch-plugin\\" href=\\"https://twitter.com/wesbos/timelines/1189618481672667136\\">🔥 Hot Tips from Wes Bos - Curated tweets by wesbos</a>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-twitter-url.com\\">https://not-a-twitter-url.com</a></p>
+    <p><a href=\\"https://this-is-not-twitter.com\\">https://this-is-not-twitter.com</a></p>
+    <p><a href=\\"https://this-is-not-twitter.com/i/events/123\\">https://this-is-not-twitter.com/i/events/123</a></p>
+    <p><a href=\\"https://this-is-not-twitter.com/i/moments/123\\">https://this-is-not-twitter.com/i/moments/123</a></p>
+    <p><a href=\\"https://this-is-not-twitter.com/foobar/status/123\\">https://this-is-not-twitter.com/foobar/status/123</a></p>
+    <p><a href=\\"https://this-is-not-twitter.com/foobar/timelines/123\\">https://this-is-not-twitter.com/foobar/timelines/123</a></p>
+    <p><a href=\\"https://twitter.com/MichaelDeBoey93\\">https://twitter.com/MichaelDeBoey93</a></p>
+    <p><a href=\\"https://twitter.com/i/moments/edit/994601867987619840\\">https://twitter.com/i/moments/edit/994601867987619840</a></p>
+    <p><blockquote class=\\"twitter-tweet-mocked-fetch-plugin\\"><p lang=\\"en\\" dir=\\"ltr\\">example</p>&mdash; Kent C. Dodds (@kentcdodds) <a href=\\"https://twitter.com/kentcdodds/status/1078755736455278592\\">December 28, 2018</a></blockquote></p>
+    <p><blockquote class=\\"twitter-tweet-mocked-fetch-plugin\\"><p lang=\\"en\\" dir=\\"ltr\\">example</p>&mdash; Kent C. Dodds (@kentcdodds) <a href=\\"https://twitter.com/kentcdodds/status/1078755736455278592\\">December 28, 2018</a></blockquote></p>
+    <p><a class=\\"twitter-moment-mocked-fetch-plugin\\" href=\\"https://twitter.com/i/moments/994601867987619840\\">🔥 Design Tips</a></p>
+    <p><a class=\\"twitter-moment-mocked-fetch-plugin\\" href=\\"https://twitter.com/i/moments/994601867987619840\\">🔥 Design Tips</a></p>
+    <p><a class=\\"twitter-moment-mocked-fetch-plugin\\" href=\\"https://twitter.com/i/moments/994601867987619840\\">🔥 Design Tips</a></p>
+    <p><a class=\\"twitter-moment-mocked-fetch-plugin\\" href=\\"https://twitter.com/i/moments/994601867987619840\\">🔥 Design Tips</a></p>
+    <p><a class=\\"twitter-timeline-mocked-fetch-plugin\\" href=\\"https://twitter.com/wesbos/timelines/1189618481672667136\\">🔥 Hot Tips from Wes Bos - Curated tweets by wesbos</a></p>
+    <p><a class=\\"twitter-timeline-mocked-fetch-plugin\\" href=\\"https://twitter.com/wesbos/timelines/1189618481672667136\\">🔥 Hot Tips from Wes Bos - Curated tweets by wesbos</a></p>
     "
   `);
 });

--- a/src/__tests__/transformers/YouTube.js
+++ b/src/__tests__/transformers/YouTube.js
@@ -8,7 +8,7 @@ import {
   shouldTransform,
 } from '../../transformers/YouTube';
 
-import { cache, getMarkdownASTForFile, parseASTToMarkdown } from '../helpers';
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
 
 cases(
   'url validation',
@@ -150,34 +150,21 @@ test('Plugin can transform YouTube links', async () => {
 
   const processedAST = await plugin({ cache, markdownAST });
 
-  expect(parseASTToMarkdown(processedAST)).toMatchInlineSnapshot(`
-    "<https://not-a-youtube-url.com>
-
-    <https://this-is-not-youtu.be>
-
-    <https://this-is-not-youtube.com>
-
-    <https://this-is-not-youtube.com/watch?v=dQw4w9WgXcQ>
-
-    <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
-
-    <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
-
-    <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
-
-    <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
-
-    <iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe>
-
-    <https://youtube.com/channel/UCXBhQ05nu3L1abBUGeQ0ahw>
-
-    <https://youtube.com/c/ReactRally>
-
-    <https://youtube.com/playlist?list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u>
-
-    <https://youtube.com/user/kentdoddsfamily>
-
-    <https://youtube.com/kentdoddsfamily>
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    "<p><a href=\\"https://not-a-youtube-url.com\\">https://not-a-youtube-url.com</a></p>
+    <p><a href=\\"https://this-is-not-youtu.be\\">https://this-is-not-youtu.be</a></p>
+    <p><a href=\\"https://this-is-not-youtube.com\\">https://this-is-not-youtube.com</a></p>
+    <p><a href=\\"https://this-is-not-youtube.com/watch?v=dQw4w9WgXcQ\\">https://this-is-not-youtube.com/watch?v=dQw4w9WgXcQ</a></p>
+    <p><iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe></p>
+    <p><iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe></p>
+    <p><iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe></p>
+    <p><iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe></p>
+    <p><iframe width=\\"100%\\" height=\\"315\\" src=\\"https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?rel=0\\" frameBorder=\\"0\\" allow=\\"accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture\\" allowFullScreen></iframe></p>
+    <p><a href=\\"https://youtube.com/channel/UCXBhQ05nu3L1abBUGeQ0ahw\\">https://youtube.com/channel/UCXBhQ05nu3L1abBUGeQ0ahw</a></p>
+    <p><a href=\\"https://youtube.com/c/ReactRally\\">https://youtube.com/c/ReactRally</a></p>
+    <p><a href=\\"https://youtube.com/playlist?list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u\\">https://youtube.com/playlist?list=PLV5CVI1eNcJgCrPH_e6d57KRUTiDZgs0u</a></p>
+    <p><a href=\\"https://youtube.com/user/kentdoddsfamily\\">https://youtube.com/user/kentdoddsfamily</a></p>
+    <p><a href=\\"https://youtube.com/kentdoddsfamily\\">https://youtube.com/kentdoddsfamily</a></p>
     "
   `);
 });


### PR DESCRIPTION
**What**:

This changes the tests to test what HTML (or equivalent JSX) a processor will eventually end up with.

**Why**:

To show that https://github.com/MichaelDeBoey/gatsby-remark-embedder/pull/167 works and won’t change anything (meaningful).

**How**:

Serialize the resulting tree as HTML.

**Checklist**:

- [x] Documentation n/a
- [x] Tests n/a
- [x] Ready to be merged yes
