### PR TITLE
feat(StackBlitz): Add support for StackBlitz

### DIFF
--- a/src/__tests__/transformers/StackBlitz.js
+++ b/src/__tests__/transformers/StackBlitz.js
@@ -1,0 +1,58 @@
+import cases from 'jest-in-case';
+
+import plugin from '../../';
+import { getHTML, shouldTransform } from '../../transformers/StackBlitz';
+
+import { cache, getMarkdownASTForFile, mdastToHtml } from '../helpers';
+
+cases(
+  'url validation',
+  ({ url, valid }) => {
+    expect(shouldTransform(url)).toBe(valid);
+  },
+  {
+    'non-StackBlitz url': {
+      url: 'https://not-a-stackblitz-url.com',
+      valid: false,
+    },
+    "non-StackBlitz url ending with 'stackblitz.com'": {
+      url: 'https://this-is-not-stackblitz.com',
+      valid: false,
+    },
+    "non-CodeSandbox url ending with 'stackblitz.com' having '/edit/'": {
+      url: 'https://this-is-not-stackblitz.com/edit/start-to-source-1-ng-template',
+      valid: false,
+    },
+    'embed url': {
+      url: 'https://stackblitz.com/edit/start-to-source-1-ng-template',
+      valid: true,
+    },
+    'embed url with parameters': {
+      url: 'https://stackblitz.com/edit/start-to-source-1-ng-template?file=src/app/app.component.ts',
+      valid: true,
+    },
+  }
+);
+
+test('Gets the correct StackBlitz iframe', () => {
+  const html = getHTML('https://stackblitz.com/edit/start-to-source-1-ng-template');
+
+  expect(html).toMatchInlineSnapshot(
+    `<iframe src="https://stackblitz.com/edit/start-to-source-1-ng-template?embed=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`
+  );
+});
+
+test('Plugin can transform StackBlitz links', async () => {
+  const markdownAST = getMarkdownASTForFile('StackBlitz');
+
+  const processedAST = await plugin({ cache, markdownAST });
+
+  expect(mdastToHtml(processedAST)).toMatchInlineSnapshot(`
+    <p>https://not-a-stackblitz-url.com</p>
+    <p>https://this-is-not-stackblitz.com</p>
+    <p>https://this-is-not-stackblitz.com/edit/start-to-source-1-ng-template</p>
+    <iframe src="https://stackblitz.com/edit/start-to-source-1-ng-template?embed=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+    <iframe src="https://stackblitz.com/edit/start-to-source-1-ng-template?embed=1&file=src/app/app.component.ts" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+
+  `);
+});

--- a/src/__tests__/transformers/__fixtures__/StackBlitz.md
+++ b/src/__tests__/transformers/__fixtures__/StackBlitz.md
@@ -1,0 +1,9 @@
+https://not-a-stackblitz-url.com
+
+https://this-is-not-stackblitz.com
+
+https://this-is-not-stackblitz.com/edit/start-to-source-1-ng-template
+
+https://stackblitz.com/edit/start-to-source-1-ng-template
+
+https://stackblitz.com/edit/start-to-source-1-ng-template?file=src/app/app.component.ts

--- a/src/transformers/StackBlitz.js
+++ b/src/transformers/StackBlitz.js
@@ -1,0 +1,28 @@
+export const shouldTransform = (url) => {
+  const { host, pathname } = new URL(url);
+
+  return (
+    ['stackblitz.com'].includes(host) &&
+    pathname.includes('/edit/')
+  );
+};
+
+export const getStackBlitzEmbedIframe = (url) => {
+  const editRegex = /(.*\/edit\/.*?)((?:\?.*$)|$)/;
+  const regexResults = editRegex.exec(url);
+  const base = regexResults[1];
+  let queryStr = regexResults[2];
+  if (queryStr) {
+    queryStr = queryStr.replace('?', '?embed=1&');
+  } else {
+    queryStr = '?embed=1';
+  }
+
+  return `${base}${queryStr}`;
+}
+
+export const getHTML = (url) => {
+  const iframeUrl = getStackBlitzEmbedIframe(url);
+
+  return `<iframe src="${iframeUrl}" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>`;
+};

--- a/src/transformers/index.js
+++ b/src/transformers/index.js
@@ -7,6 +7,7 @@ import * as PinterestTransformer from './Pinterest';
 import * as SlidesTransformer from './Slides';
 import * as SoundCloudTransformer from './SoundCloud';
 import * as SpotifyTransformer from './Spotify';
+import * as StackBlitzTransformer from './StackBlitz';
 import * as StreamableTransformer from './Streamable';
 import * as TestingPlaygroundTransformer from './TestingPlayground';
 import * as TwitchTransformer from './Twitch';
@@ -23,6 +24,7 @@ export const defaultTransformers = [
   SlidesTransformer,
   SoundCloudTransformer,
   SpotifyTransformer,
+  StackBlitzTransformer,
   StreamableTransformer,
   TestingPlaygroundTransformer,
   TwitchTransformer,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: StackBlitz is being added to the list of supported vendors

<!-- Why are these changes necessary? -->

**Why**: Many sites may use StackBlitz to embed usage of code samples into their blog. I [run one such site myself](https://unicorn-utterances.com), and intend to use this plugin once these changes are merged

<!-- How were these changes implemented? -->

**How**: We implement a regex for the functionality behind the embed like other services do

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests*
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I will be adding documentation once the tests are finally passing - I am asking  for help debugging these tests

<!-- feel free to add additional comments -->

I am making a WIP PR as I feel that I've ran into a bug somewhere along the line with the tests I wrote. I keep running into the following error:

```
 FAIL  src/__tests__/transformers/StackBlitz.js
  ● Plugin can transform StackBlitz links

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `Plugin can transform StackBlitz links 1`

    - Snapshot  - 1
    + Received  + 1

      <p>https://not-a-stackblitz-url.com</p>
      <p>https://this-is-not-stackblitz.com</p>
      <p>https://this-is-not-stackblitz.com/edit/start-to-source-1-ng-template</p>
      <iframe src="https://stackblitz.com/edit/start-to-source-1-ng-template?embed=1" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
    - <iframe src="https://stackblitz.com/edit/start-to-source-1-ng-template?embed=1&file=src/app/app.component.ts" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
    + <iframe src="https://stackblitz.com/edit/start-to-source-1-ng-template?embed=1&#x26;file=src/app/app.component.ts" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
```

> Notice the "expected" `embed=1&` vs the "received" `embed=1&#x26`

I'm not sure why this is happening and I'm not entirely confident that this issue is a result of my code - I'm asking for help figuring this one out 😅 

Once initial support for StackBlitz is added, I intend to add further functionality by adding support for optional configuration for StackBlitz embeds 