### PR TITLE
Ensure deterministic builds when multiple transformers match

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default async (
   { cache, markdownAST },
   { customTransformers = [], services = {} } = {}
 ) => {
-  const transformers = [...defaultTransformers, ...customTransformers];
+  const transformers = [...customTransformers, ...defaultTransformers];
 
   const transformations = [];
   visit(markdownAST, 'paragraph', (paragraphNode) => {

--- a/src/index.js
+++ b/src/index.js
@@ -50,37 +50,43 @@ export default async (
       return;
     }
 
-    transformers
-      .filter(({ shouldTransform }) => shouldTransform(urlString))
-      .forEach(({ getHTML, name = '' }) => {
-        transformations.push(async () => {
-          try {
-            let html = await cache.get(urlString);
+    const transformer = transformers.find(({ shouldTransform }) =>
+      shouldTransform(urlString)
+    );
 
-            if (!html) {
-              html = await getHTML(urlString, services[name] || {});
-              await cache.set(urlString, html);
-            }
+    if (!transformer) {
+      return;
+    }
 
-            // if nothing's returned from getHTML, then no modifications are needed
-            if (!html) return;
+    const { getHTML, name = '' } = transformer;
 
-            // convert the HTML string into an AST
-            const htmlElement = htmlToHast(html);
+    transformations.push(async () => {
+      try {
+        let html = await cache.get(urlString);
 
-            // set the paragraphNode.data with the necessary properties
-            paragraphNode.data = {
-              hName: htmlElement.tagName,
-              hProperties: htmlElement.properties,
-              hChildren: htmlElement.children,
-            };
-          } catch (error) {
-            error.message = `The following error appeared while processing '${urlString}':\n\n${error.message}`;
+        if (!html) {
+          html = await getHTML(urlString, services[name] || {});
+          await cache.set(urlString, html);
+        }
 
-            throw error;
-          }
-        });
-      });
+        // if nothing's returned from getHTML, then no modifications are needed
+        if (!html) return;
+
+        // convert the HTML string into an AST
+        const htmlElement = htmlToHast(html);
+
+        // set the paragraphNode.data with the necessary properties
+        paragraphNode.data = {
+          hName: htmlElement.tagName,
+          hProperties: htmlElement.properties,
+          hChildren: htmlElement.children,
+        };
+      } catch (error) {
+        error.message = `The following error appeared while processing '${urlString}':\n\n${error.message}`;
+
+        throw error;
+      }
+    });
   });
 
   await Promise.all(transformations.map((t) => t()));


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Ensures only 1 transformer per URL is scheduled.

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

Using custom transformers for sites this plugin already supports leads to undeterministic builds. Whichever plugin resolves the promise first, gets the node.

**How**:

Use `.find` instead of `.filter` to default to the first possible transformer.
Prioritize custom transformers by inverting the `transformers` array.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Existing tests are passing. Don't think a change to documentation is needed.