### PR TITLE
Added height and width props to Twitch service

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,8 @@ All options should go under the `Twitch` namespace.
 | name   | Type                  | Required | Default | Description                                                                                           |
 | ------ | --------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------- |
 | parent | `string` / `string[]` | ✅       |         | Domain(s) that will be embedding Twitch. You must have one parent key for each domain your site uses. |
+| height | `string`              |          | 300     | The height of the containing iframe                                                                   |
+| width  | `string`              |          | 100%    | The width of the containing iframe                                                                    |
 
 ##### parent
 

--- a/src/__tests__/transformers/Twitch.js
+++ b/src/__tests__/transformers/Twitch.js
@@ -205,6 +205,18 @@ test('Gets the correct Twitch iframe', () => {
   );
 });
 
+test('Gets the correct Twitch iframe with custom dimensions', () => {
+  const html = getHTML('https://twitch.tv/videos/546761743', {
+    parent: 'embed.example.com',
+    width: '50%',
+    height: '50%',
+  });
+
+  expect(html).toMatchInlineSnapshot(
+    `<iframe src="https://player.twitch.tv?video=546761743&parent=embed.example.com" height="50%" width="50%" frameborder="0" scrolling="no" allowfullscreen></iframe>`
+  );
+});
+
 test('Plugin can transform Twitch links', async () => {
   const markdownAST = getMarkdownASTForFile('Twitch');
 

--- a/src/transformers/Twitch.js
+++ b/src/transformers/Twitch.js
@@ -91,12 +91,12 @@ export const normalizeParent = (parent) => {
   return parent;
 };
 
-export const getHTML = (url, { parent }) => {
+export const getHTML = (url, { parent, width = '100%', height = '300' }) => {
   const iframeUrl = `${getTwitchIFrameSrc(url)}&parent=${normalizeParent(
     parent
   )}`;
 
-  return `<iframe src="${iframeUrl}" height="300" width="100%" frameborder="0" scrolling="no" allowfullscreen></iframe>`;
+  return `<iframe src="${iframeUrl}" height="${height}" width="${width}" frameborder="0" scrolling="no" allowfullscreen></iframe>`;
 };
 
 export const name = 'Twitch';


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add the ability to pass custom height and width to Twitch embeds 

<!-- Why are these changes necessary? -->

**Why**: Consumers of plugin may need to customize the height of the embed (such as my project)

<!-- How were these changes implemented? -->

**How**: Add option to render function, added tests, updated documentation

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Related issue: https://github.com/MichaelDeBoey/gatsby-remark-embedder/issues/144
Related PR: https://github.com/MichaelDeBoey/gatsby-remark-embedder/pull/151

I'd be happy to add this logic to every other service with hardcoded options if that would be helpful for the project